### PR TITLE
Added a "Test for log directory" function. (SSLSplit) (Take 2)

### DIFF
--- a/SSLsplit/module.info
+++ b/SSLsplit/module.info
@@ -6,5 +6,5 @@
         "tetra"
     ],
     "title": "SSLsplit",
-    "version": "1.1"
+    "version": "1.2"
 }

--- a/SSLsplit/scripts/autostart_sslsplit.sh
+++ b/SSLsplit/scripts/autostart_sslsplit.sh
@@ -20,5 +20,5 @@ iptables -P OUTPUT ACCEPT
 sh /pineapple/modules/SSLsplit/rules/iptables
 
 iptables -t nat -A POSTROUTING -j MASQUERADE
-
+echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We are creating it now!\n" > /pineapple/modules/SSLsplit/connections.log && mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere
 sslsplit -D -l /pineapple/modules/SSLsplit/connections.log -L /pineapple/modules/SSLsplit/log/output_${MYTIME}.log -k /pineapple/modules/SSLsplit/cert/certificate.key -c /pineapple/modules/SSLsplit/cert/certificate.crt ssl 0.0.0.0 8443 tcp 0.0.0.0 8080

--- a/SSLsplit/scripts/autostart_sslsplit.sh
+++ b/SSLsplit/scripts/autostart_sslsplit.sh
@@ -20,5 +20,5 @@ iptables -P OUTPUT ACCEPT
 sh /pineapple/modules/SSLsplit/rules/iptables
 
 iptables -t nat -A POSTROUTING -j MASQUERADE
-echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We are creating it now!\n" > /pineapple/modules/SSLsplit/connections.log && mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere
+echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! Your welcome. :) \n" > /pineapple/modules/SSLsplit/output_${MYTIME}.log
 sslsplit -D -l /pineapple/modules/SSLsplit/connections.log -L /pineapple/modules/SSLsplit/log/output_${MYTIME}.log -k /pineapple/modules/SSLsplit/cert/certificate.key -c /pineapple/modules/SSLsplit/cert/certificate.crt ssl 0.0.0.0 8443 tcp 0.0.0.0 8080

--- a/SSLsplit/scripts/autostart_sslsplit.sh
+++ b/SSLsplit/scripts/autostart_sslsplit.sh
@@ -20,5 +20,5 @@ iptables -P OUTPUT ACCEPT
 sh /pineapple/modules/SSLsplit/rules/iptables
 
 iptables -t nat -A POSTROUTING -j MASQUERADE
-echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! Your welcome. :) \n" > /pineapple/modules/SSLsplit/output_${MYTIME}.log
+echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! You're welcome. :) \n" > /pineapple/modules/SSLsplit/log/output_${MYTIME}.log
 sslsplit -D -l /pineapple/modules/SSLsplit/connections.log -L /pineapple/modules/SSLsplit/log/output_${MYTIME}.log -k /pineapple/modules/SSLsplit/cert/certificate.key -c /pineapple/modules/SSLsplit/cert/certificate.crt ssl 0.0.0.0 8443 tcp 0.0.0.0 8080

--- a/SSLsplit/scripts/autostart_sslsplit.sh
+++ b/SSLsplit/scripts/autostart_sslsplit.sh
@@ -20,5 +20,5 @@ iptables -P OUTPUT ACCEPT
 sh /pineapple/modules/SSLsplit/rules/iptables
 
 iptables -t nat -A POSTROUTING -j MASQUERADE
-echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! You're welcome. :) \n" > /pineapple/modules/SSLsplit/log/output_${MYTIME}.log
+echo "If this file exists, it means that the script succesfully detected the log directory!" > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! You're welcome. :) \n" > /pineapple/modules/SSLsplit/log/output_${MYTIME}.log
 sslsplit -D -l /pineapple/modules/SSLsplit/connections.log -L /pineapple/modules/SSLsplit/log/output_${MYTIME}.log -k /pineapple/modules/SSLsplit/cert/certificate.key -c /pineapple/modules/SSLsplit/cert/certificate.crt ssl 0.0.0.0 8443 tcp 0.0.0.0 8080

--- a/SSLsplit/scripts/sslsplit.sh
+++ b/SSLsplit/scripts/sslsplit.sh
@@ -22,7 +22,7 @@ if [ "$1" = "start" ]; then
 	sh /pineapple/modules/SSLsplit/rules/iptables
 
 	iptables -t nat -A POSTROUTING -j MASQUERADE
-
+	echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We are creating it now!\n" > /pineapple/modules/SSLsplit/connections.log && mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere
 	sslsplit -D -l /pineapple/modules/SSLsplit/connections.log -L /pineapple/modules/SSLsplit/log/output_${MYTIME}.log -k /pineapple/modules/SSLsplit/cert/certificate.key -c /pineapple/modules/SSLsplit/cert/certificate.crt ssl 0.0.0.0 8443 tcp 0.0.0.0 8080
 
 elif [ "$1" = "stop" ]; then

--- a/SSLsplit/scripts/sslsplit.sh
+++ b/SSLsplit/scripts/sslsplit.sh
@@ -22,7 +22,7 @@ if [ "$1" = "start" ]; then
 	sh /pineapple/modules/SSLsplit/rules/iptables
 
 	iptables -t nat -A POSTROUTING -j MASQUERADE
-	echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We are creating it now!\n" > /pineapple/modules/SSLsplit/connections.log && mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere
+	echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! Your welcome. :) \n" > /pineapple/modules/SSLsplit/output_${MYTIME}.log
 	sslsplit -D -l /pineapple/modules/SSLsplit/connections.log -L /pineapple/modules/SSLsplit/log/output_${MYTIME}.log -k /pineapple/modules/SSLsplit/cert/certificate.key -c /pineapple/modules/SSLsplit/cert/certificate.crt ssl 0.0.0.0 8443 tcp 0.0.0.0 8080
 
 elif [ "$1" = "stop" ]; then

--- a/SSLsplit/scripts/sslsplit.sh
+++ b/SSLsplit/scripts/sslsplit.sh
@@ -22,7 +22,7 @@ if [ "$1" = "start" ]; then
 	sh /pineapple/modules/SSLsplit/rules/iptables
 
 	iptables -t nat -A POSTROUTING -j MASQUERADE
-	echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! You're welcome. :) \n" > /pineapple/modules/SSLsplit/log/output_${MYTIME}.log
+	echo "If this file exists, it means that the script succesfully detected the log directory!" > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! You're welcome. :) \n" > /pineapple/modules/SSLsplit/log/output_${MYTIME}.log
 	sslsplit -D -l /pineapple/modules/SSLsplit/connections.log -L /pineapple/modules/SSLsplit/log/output_${MYTIME}.log -k /pineapple/modules/SSLsplit/cert/certificate.key -c /pineapple/modules/SSLsplit/cert/certificate.crt ssl 0.0.0.0 8443 tcp 0.0.0.0 8080
 
 elif [ "$1" = "stop" ]; then

--- a/SSLsplit/scripts/sslsplit.sh
+++ b/SSLsplit/scripts/sslsplit.sh
@@ -22,7 +22,7 @@ if [ "$1" = "start" ]; then
 	sh /pineapple/modules/SSLsplit/rules/iptables
 
 	iptables -t nat -A POSTROUTING -j MASQUERADE
-	echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! Your welcome. :) \n" > /pineapple/modules/SSLsplit/output_${MYTIME}.log
+	echo "If this file exists, it means that the script succesfully detected the log directory! > /pineapple/modules/SSLsplit/log/islogthere || mkdir /pineapple/modules/SSLsplit/log/ && echo "Directory succesfully created!" > /pineapple/modules/SSLsplit/log/islogthere && printf "WRN: Log directory at '/pineapple/modules/SSLsplit/' was not found! We just created it for you! You're welcome. :) \n" > /pineapple/modules/SSLsplit/log/output_${MYTIME}.log
 	sslsplit -D -l /pineapple/modules/SSLsplit/connections.log -L /pineapple/modules/SSLsplit/log/output_${MYTIME}.log -k /pineapple/modules/SSLsplit/cert/certificate.key -c /pineapple/modules/SSLsplit/cert/certificate.crt ssl 0.0.0.0 8443 tcp 0.0.0.0 8080
 
 elif [ "$1" = "stop" ]; then


### PR DESCRIPTION
This is a commit pull request concerning a particular error that occurs when SSLsplit can not write to a non-existing directory. I have added a function that will check for the existence of the log directory and will automatically create it, should the test command fail. This is for the module "SSLSplit" by WhistleMaster.
I will note the following PR: #14
I don't know why, but the log directory might get deleted or may not get created at all. This pull request will add a fail-safe mechanism to make sure this does not happen!

Edit: I don't think "||" is used commonly in the scripting world, Here is the reference. https://stackoverflow.com/questions/22009364/is-there-a-try-catch-command-in-bash (Note this works in ASH as well.)
Note: This may have comments/help from trashbo4t, but due to the way he treated me, i am discrediting him. 