### PR TITLE
Tor

### DIFF
--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -137,28 +137,29 @@ class Tor extends Module
 
         $device = $this->getDevice();
         $sdAvailable = $this->isSDAvailable();
-        $installed = true;
-        $install = "Installed";
+        $installed = false;
+        $install = "Not Installed";
         $processing = false;
 
         if (file_exists($this->progressFile)) {
             // TOR Is installing, please wait.
             $install = "Installing...";
-            $installed = false;
             $installLabel = self::WARNING;
             $processing = true;
 
             $status = "Not running";
             $statusLabel = self::DANGER;
-        } elseif (!$this->checkDependency("tor")) {
+        }
+        else if (!$this->checkDependency("tor")) {
             // TOR is not installed, please install.
-            $install = "Not installed";
             $installLabel = self::DANGER;
 
             $status = "Start";
-            $statusLabel = self::SUCCESS;
+            $statusLabel = self::DANGER;
         } else {
             // TOR is installed, please configure.
+            $installed = true;
+            $install = "Installed";
             $installLabel = self::SUCCESS;
 
             if ($this->checkRunning("tor")) {

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -199,6 +199,8 @@ class Tor extends Module
     private function reloadTor()
     {
         $this->generateConfig();
+        //Sending SIGHUP to tor process cause config reload.
+        exec("pkill -sighup tor$");
     }
 
     private function refreshHiddenServices()

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -20,6 +20,9 @@ class tor extends Module
 			case 'toggletor':
 				$this->toggletor();
 				break;
+			case 'refreshHiddenServices':
+				$this->refreshHiddenServices();
+				break;
 			case 'addHiddenService':
 				$this->addHiddenService();
 				break;
@@ -140,9 +143,17 @@ class tor extends Module
 
         $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
     }
+
+	private function refreshHiddenServices() {
+		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
+		$this->response = array("hiddenServices" => $hiddenServices);
+	}
 	private function addHiddenService() {
-		$config = @json_decode(file_get_contents("/etc/config/tor/config"));
-		$this->response = array("config" => $config);
+		//Perform gate checks here...
+		$hiddenService = array("name" => $this->request->name, "forwards" => array() );
+		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
+		array_push($hiddenServices, $hiddenService);
+		file_put_contents("/etc/config/tor/config", json_encode($hiddenServices, JSON_PRETTY_PRINT));
 	}
 	private function removeHiddenService() {
 	}

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -45,7 +45,7 @@ class tor extends Module
 
 	protected function checkRunning($processName)
 	{
-		return (exec("pgrep ^{$processName}$") != '');
+		return (exec("pgrep {$processName}") != '');
 	}
 
     private function handleDependencies()
@@ -141,7 +141,8 @@ class tor extends Module
         $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
     }
 	private function addHiddenService() {
-
+		$config = @json_decode(file_get_contents("/etc/config/tor/config"));
+		$this->response = array("config" => $config);
 	}
 	private function removeHiddenService() {
 	}

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -4,6 +4,7 @@ class Tor extends Module
 {
     private $progressFile = '/tmp/tor.progress';
     private $moduleConfigFile = '/etc/config/tor/config';
+    private $dependenciesScriptFile = '/pineapple/modules/tor/scripts/dependencies.sh';
 
     // Error Constants
     const INVALID_NAME = 'Invalid name';
@@ -105,9 +106,9 @@ class Tor extends Module
         }
 
         if (!$this->checkDependency("tor")) {
-            $this->execBackground("/pineapple/modules/tor/scripts/dependencies.sh install " . $destination);
+            $this->execBackground($this->dependenciesScriptFile . " install " . $destination);
         } else {
-            $this->execBackground("/pineapple/modules/tor/scripts/dependencies.sh remove");
+            $this->execBackground($this->dependenciesScriptFile . " remove");
         }
         $this->success(true);
     }

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -281,19 +281,6 @@ class Tor extends Module
         $port = $this->request->port;
         $redirect_to = $this->request->redirect_to;
 
-        if (!$this->isValidName($name)) {
-            $this->error(self::INVALID_NAME);
-            return;
-        }
-        if (!$this->isValidPort($port)) {
-            $this->error(self::INVALID_PORT);
-            return;
-        }
-        if (!$this->isValidRedirectTo($redirect_to)) {
-            $this->error(self::INVALID_DESTINATION);
-            return;
-        }
-
         $hiddenServices = @json_decode(file_get_contents($this->moduleConfigFile));
         foreach ($hiddenServices as $hiddenService) {
             if ($hiddenService->name == $name) {

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -66,7 +66,7 @@ class Tor extends Module
 
     protected function checkRunning($processName)
     {
-        return (exec("pgrep {$processName}") != '');
+        return (exec("pgrep '{$processName}$'") != '');
     }
 
     private function handleDependencies()

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -199,7 +199,6 @@ class tor extends Module
 			return;
 		}
 
-		file_put_contents('/tmp/name',$name);
 		$hiddenService = array("name" => $name, "forwards" => array() );
 		$hiddenServices = array();
 		if(file_exists("/etc/config/tor/config")) {

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -149,8 +149,7 @@ class Tor extends Module
 
             $status = "Not running";
             $statusLabel = self::DANGER;
-        }
-        else if (!$this->checkDependency("tor")) {
+        } elseif (!$this->checkDependency("tor")) {
             // TOR is not installed, please install.
             $installLabel = self::DANGER;
 

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -17,9 +17,6 @@ class tor extends Module
             case 'handleDependenciesStatus':
                 $this->handleDependenciesStatus();
                 break;
-			case 'toggletorOnBoot':
-				$this->toggletorOnBoot();
-				break;
 			case 'toggletor':
 				$this->toggletor();
 				break;
@@ -73,26 +70,6 @@ class tor extends Module
         else
         {
             $this->response = array('success' => true);
-        }
-    }
-
-	private function checkAutoStart()
-	{
-		return (exec("cat /etc/rc.local | grep tor/scripts/autostart_tor.sh") != '');
-	}
-
-    private function toggletorOnBoot()
-    {
-        if($this->checkAutoStart())
-        {
-            exec("sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local");
-        }
-        else
-        {
-			exec("sed -i '/exit 0/d' /etc/rc.local");
-            exec("echo /pineapple/modules/tor/scripts/autostart_tor.sh >> /etc/rc.local");
-            exec("echo exit 0 >> /etc/rc.local");
-
         }
     }
 
@@ -159,12 +136,6 @@ class tor extends Module
         {
 			$status = "Stopped";
             $statusLabel = "danger";
-        }
-
-        if($this->checkAutoStart())
-        {
-            $bootLabelON = "success";
-            $bootLabelOFF = "default";
         }
 
         $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -45,7 +45,7 @@ class tor extends Module
 
 	protected function checkRunning($processName)
 	{
-		return (exec("pgrep {$processName}") != '');
+		return (exec("pgrep ^{$processName}$") != '');
 	}
 
     private function handleDependencies()

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -152,7 +152,7 @@ class tor extends Module
 		$output .= "\n";
 		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
 		foreach($hiddenServices as $hiddenService) {
-			$output .= "HiddenServiceDir /var/lib/tor/services/{$hiddenService->name}\n";
+			$output .= "HiddenServiceDir /etc/config/tor/services/{$hiddenService->name}\n";
 			$forwards = $hiddenService->forwards;
 			foreach($forwards as $forward) {
 				$output .= "HiddenServicePort {$forward->port} {$forward->redirect_to}\n";
@@ -168,8 +168,8 @@ class tor extends Module
 	private function refreshHiddenServices() {
 		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
 		foreach($hiddenServices as $hiddenService) {
-			if(file_exists("/var/lib/tor/services/{$hiddenService->name}/hostname")) {
-				$hiddenService->hostname = trim(file_get_contents("/var/lib/tor/services/{$hiddenService->name}/hostname"));
+			if(file_exists("/etc/config/tor/services/{$hiddenService->name}/hostname")) {
+				$hiddenService->hostname = trim(file_get_contents("/etc/config/tor/services/{$hiddenService->name}/hostname"));
 			}
 		}
 		$this->response = array("hiddenServices" => $hiddenServices);

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -1,0 +1,163 @@
+<?php namespace pineapple;
+
+class tor extends Module
+{
+    public function route()
+    {
+        switch ($this->request->action) {
+            case 'refreshInfo':
+                $this->refreshInfo();
+                break;
+			case 'refreshStatus':
+				$this->refreshStatus();
+				break;
+            case 'handleDependencies':
+                $this->handleDependencies();
+                break;
+            case 'handleDependenciesStatus':
+                $this->handleDependenciesStatus();
+                break;
+			case 'toggletorOnBoot':
+				$this->toggletorOnBoot();
+				break;
+			case 'toggletor':
+				$this->toggletor();
+				break;
+        }
+    }
+
+    protected function checkDependency($dependencyName)
+    {
+        return ((exec("which {$dependencyName}") == '' ? false : true) &&  !file_exists("/tmp/tor.progress"));
+    }
+
+    protected function refreshInfo()
+    {
+        $moduleInfo = @json_decode(file_get_contents("/pineapple/modules/tor/module.info"));
+        $this->response = array('title' => $moduleInfo->title, 'version' => $moduleInfo->version);
+    }
+
+	protected function checkRunning($processName)
+	{
+		return (exec("pgrep {$processName}") != '');
+	}
+
+    private function handleDependencies()
+    {
+        if(!$this->checkDependency("tor"))
+        {
+            $this->execBackground("/pineapple/modules/tor/scripts/dependencies.sh install " . $this->request->destination);
+        }
+        else
+        {
+            $this->execBackground("/pineapple/modules/tor/scripts/dependencies.sh remove");
+        }
+        $this->response = array('success' => true);
+    }
+
+    private function handleDependenciesStatus()
+    {
+        if (file_exists('/tmp/tor.progress'))
+        {
+            $this->response = array('success' => false);
+        }
+        else
+        {
+            $this->response = array('success' => true);
+        }
+    }
+
+	private function checkAutoStart()
+	{
+		return (exec("cat /etc/rc.local | grep tor/scripts/autostart_tor.sh") != '');
+	}
+
+    private function toggletorOnBoot()
+    {
+        if($this->checkAutoStart())
+        {
+            exec("sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local");
+        }
+        else
+        {
+			exec("sed -i '/exit 0/d' /etc/rc.local");
+            exec("echo /pineapple/modules/tor/scripts/autostart_tor.sh >> /etc/rc.local");
+            exec("echo exit 0 >> /etc/rc.local");
+
+        }
+    }
+
+	private function toggletor()
+	{
+		if($this->checkRunning("tor"))
+		{
+			exec("/etc/init.d/tor stop");
+		}
+		else
+		{
+			exec("/etc/init.d/tor start");
+		}
+	}
+
+    private function refreshStatus()
+    {
+
+        $device = $this->getDevice();
+        $sdAvailable = $this->isSDAvailable();
+		$installed = false;
+        $bootLabelON = "default";
+        $bootLabelOFF = "danger";
+        $processing = false;
+
+        if (file_exists('/tmp/tor.progress'))
+        {
+			// TOR Is installing, please wait.
+            $install = "Installing...";
+            $installLabel = "warning";
+            $processing = true;
+
+            $status = "Not running";
+            $statusLabel = "danger";
+
+	        $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
+			return;
+		}
+
+        if (!$this->checkDependency("tor"))
+        {
+			// TOR is not installed, please install.
+            $install = "Not installed";
+            $installLabel = "danger";
+
+            $status = "Start";
+            $statusLabel = "success";
+			
+	        $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
+			return;
+        }
+
+		// TOR is installed, please configure.
+        $installed = true;
+        $install = "Installed";
+        $installLabel = "success";
+
+        if($this->checkRunning("tor"))
+        {
+            $status = "Started";
+            $statusLabel = "success";
+        }
+        else
+        {
+			$status = "Stopped";
+            $statusLabel = "danger";
+        }
+
+        if($this->checkAutoStart())
+        {
+            $bootLabelON = "success";
+            $bootLabelOFF = "default";
+        }
+
+        $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
+    }
+}

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -1,6 +1,6 @@
 <?php namespace pineapple;
 
-class tor extends Module
+class Tor extends Module
 {
     public function route()
     {
@@ -8,47 +8,50 @@ class tor extends Module
             case 'refreshInfo':
                 $this->refreshInfo();
                 break;
-			case 'refreshStatus':
-				$this->refreshStatus();
-				break;
+            case 'refreshStatus':
+                $this->refreshStatus();
+                break;
             case 'handleDependencies':
                 $this->handleDependencies();
                 break;
             case 'handleDependenciesStatus':
                 $this->handleDependenciesStatus();
                 break;
-			case 'toggletor':
-				$this->toggletor();
-				break;
-			case 'refreshHiddenServices':
-				$this->refreshHiddenServices();
-				break;
-			case 'addHiddenService':
-				$this->addHiddenService();
-				break;
-			case 'removeHiddenService':
-				$this->removeHiddenService();
-			    break;
-			case 'addServiceForward':
-				$this->addServiceForward();
-				break;
-			case 'removeServiceForward':
-				$this->removeServiceForward();
-				break;
+            case 'toggletor':
+                $this->toggletor();
+                break;
+            case 'refreshHiddenServices':
+                $this->refreshHiddenServices();
+                break;
+            case 'addHiddenService':
+                $this->addHiddenService();
+                break;
+            case 'removeHiddenService':
+                $this->removeHiddenService();
+                break;
+            case 'addServiceForward':
+                $this->addServiceForward();
+                break;
+            case 'removeServiceForward':
+                $this->removeServiceForward();
+                break;
         }
     }
 
-	private function isValidName($name) {
-		return preg_match('/^[a-zA-Z0-9_]+$/', $name) === 1;
-	}
+    private function isValidName($name)
+    {
+        return preg_match('/^[a-zA-Z0-9_]+$/', $name) === 1;
+    }
 
-	private function isValidPort($port) {
-		return preg_match('/^[0-9]+$/', $port) === 1;
-	}
+    private function isValidPort($port)
+    {
+        return preg_match('/^[0-9]+$/', $port) === 1;
+    }
 
-	private function isValidRedirectTo($redirect_to) {
-		return preg_match('/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$/', $redirect_to) === 1;
-	}
+    private function isValidRedirectTo($redirect_to)
+    {
+        return preg_match('/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$/', $redirect_to) === 1;
+    }
 
     protected function checkDependency($dependencyName)
     {
@@ -61,24 +64,25 @@ class tor extends Module
         $this->response = array('title' => $moduleInfo->title, 'version' => $moduleInfo->version);
     }
 
-	protected function checkRunning($processName)
-	{
-		return (exec("pgrep {$processName}") != '');
-	}
+    protected function checkRunning($processName)
+    {
+        return (exec("pgrep {$processName}") != '');
+    }
 
     private function handleDependencies()
     {
-		if(isset($this->request->destination) && $this->request->destination != "internal" && $this->request->destination != "sd") {
-			$this->response = array('error'=>'Invalid destination');
-			return;
-		}
-
-        if(!$this->checkDependency("tor"))
-        {
-            $this->execBackground("/pineapple/modules/tor/scripts/dependencies.sh install " . $this->request->destination);
+        $destination = "";
+        if (isset($this->request->destination)) {
+            $destination = $this->request->destination;
+            if ($destination != "internal" && $destination != "sd") {
+                $this->response = array('error'=>'Invalid destination');
+                return;
+            }
         }
-        else
-        {
+
+        if (!$this->checkDependency("tor")) {
+            $this->execBackground("/pineapple/modules/tor/scripts/dependencies.sh install " . $destination);
+        } else {
             $this->execBackground("/pineapple/modules/tor/scripts/dependencies.sh remove");
         }
         $this->response = array('success' => true);
@@ -86,41 +90,34 @@ class tor extends Module
 
     private function handleDependenciesStatus()
     {
-        if (file_exists('/tmp/tor.progress'))
-        {
+        if (file_exists('/tmp/tor.progress')) {
             $this->response = array('success' => false);
-        }
-        else
-        {
+        } else {
             $this->response = array('success' => true);
         }
     }
 
-	private function toggletor()
-	{
-		if($this->checkRunning("tor"))
-		{
-			exec("/etc/init.d/tor stop");
-		}
-		else
-		{
-			exec("/etc/init.d/tor start");
-		}
-	}
+    private function toggletor()
+    {
+        if ($this->checkRunning("tor")) {
+            exec("/etc/init.d/tor stop");
+        } else {
+            exec("/etc/init.d/tor start");
+        }
+    }
 
     private function refreshStatus()
     {
 
         $device = $this->getDevice();
         $sdAvailable = $this->isSDAvailable();
-		$installed = false;
+        $installed = false;
         $bootLabelON = "default";
         $bootLabelOFF = "danger";
         $processing = false;
 
-        if (file_exists('/tmp/tor.progress'))
-        {
-			// TOR Is installing, please wait.
+        if (file_exists('/tmp/tor.progress')) {
+            // TOR Is installing, please wait.
             $install = "Installing...";
             $installLabel = "warning";
             $processing = true;
@@ -128,165 +125,195 @@ class tor extends Module
             $status = "Not running";
             $statusLabel = "danger";
 
-	        $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
-			return;
-		}
+            $this->response = array("device" => $device,
+                                    "sdAvailable" => $sdAvailable,
+                                    "status" => $status,
+                                    "statusLabel" => $statusLabel,
+                                    "installed" => $installed,
+                                    "install" => $install,
+                                    "installLabel" => $installLabel,
+                                    "bootLabelON" => $bootLabelON,
+                                    "bootLabelOFF" => $bootLabelOFF,
+                                    "processing" => $processing);
+            return;
+        }
 
-        if (!$this->checkDependency("tor"))
-        {
-			// TOR is not installed, please install.
+        if (!$this->checkDependency("tor")) {
+            // TOR is not installed, please install.
             $install = "Not installed";
             $installLabel = "danger";
 
             $status = "Start";
             $statusLabel = "success";
-			
-	        $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
-			return;
+
+            $this->response = array("device" => $device,
+                                    "sdAvailable" => $sdAvailable,
+                                    "status" => $status,
+                                    "statusLabel" => $statusLabel,
+                                    "installed" => $installed,
+                                    "install" => $install,
+                                    "installLabel" => $installLabel,
+                                    "bootLabelON" => $bootLabelON,
+                                    "bootLabelOFF" => $bootLabelOFF,
+                                    "processing" => $processing);
+            return;
         }
 
-		// TOR is installed, please configure.
+        // TOR is installed, please configure.
         $installed = true;
         $install = "Installed";
         $installLabel = "success";
 
-        if($this->checkRunning("tor"))
-        {
+        if ($this->checkRunning("tor")) {
             $status = "Started";
             $statusLabel = "success";
-        }
-        else
-        {
-			$status = "Stopped";
+        } else {
+            $status = "Stopped";
             $statusLabel = "danger";
         }
 
-        $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
+        $this->response = array("device" => $device,
+                                "sdAvailable" => $sdAvailable,
+                                "status" => $status,
+                                "statusLabel" => $statusLabel,
+                                "installed" => $installed,
+                                "install" => $install,
+                                "installLabel" => $installLabel,
+                                "bootLabelON" => $bootLabelON,
+                                "bootLabelOFF" => $bootLabelOFF,
+                                "processing" => $processing);
     }
 
-	private function generateConfig() {
-		$output = file_get_contents("/etc/config/tor/torrc");
-		$output .= "\n";
-		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
-		foreach($hiddenServices as $hiddenService) {
-			$output .= "HiddenServiceDir /etc/config/tor/services/{$hiddenService->name}\n";
-			$forwards = $hiddenService->forwards;
-			foreach($forwards as $forward) {
-				$output .= "HiddenServicePort {$forward->port} {$forward->redirect_to}\n";
-			}
-		}
-		file_put_contents("/etc/tor/torrc", $output);
-	}
+    private function generateConfig()
+    {
+        $output = file_get_contents("/etc/config/tor/torrc");
+        $output .= "\n";
+        $hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
+        foreach ($hiddenServices as $hiddenService) {
+            $output .= "HiddenServiceDir /etc/config/tor/services/{$hiddenService->name}\n";
+            $forwards = $hiddenService->forwards;
+            foreach ($forwards as $forward) {
+                $output .= "HiddenServicePort {$forward->port} {$forward->redirect_to}\n";
+            }
+        }
+        file_put_contents("/etc/tor/torrc", $output);
+    }
 
-	private function reloadTor() {
-		$this->generateConfig(); 
-	}
+    private function reloadTor()
+    {
+        $this->generateConfig();
+    }
 
-	private function refreshHiddenServices() {
-		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
-		foreach($hiddenServices as $hiddenService) {
-			if(file_exists("/etc/config/tor/services/{$hiddenService->name}/hostname")) {
-				$hiddenService->hostname = trim(file_get_contents("/etc/config/tor/services/{$hiddenService->name}/hostname"));
-			}
-		}
-		$this->response = array("hiddenServices" => $hiddenServices);
-	}
+    private function refreshHiddenServices()
+    {
+        $hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
+        foreach ($hiddenServices as $hiddenService) {
+            if (file_exists("/etc/config/tor/services/{$hiddenService->name}/hostname")) {
+                $hostname = file_get_contents("/etc/config/tor/services/{$hiddenService->name}/hostname");
+                $hiddenService->hostname = trim($hostname);
+            }
+        }
+        $this->response = array("hiddenServices" => $hiddenServices);
+    }
 
-	private function addHiddenService() {
-		$name = $this->request->name;
-		if(!$this->isValidName($name)) {
-			$this->response = array("error" => "Invalid name"); 
-			return;
-		}
+    private function addHiddenService()
+    {
+        $name = $this->request->name;
+        if (!$this->isValidName($name)) {
+            $this->response = array("error" => "Invalid name");
+            return;
+        }
 
-		$hiddenService = array("name" => $name, "forwards" => array() );
-		$hiddenServices = array();
-		if(file_exists("/etc/config/tor/config")) {
-			$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
-		}
-		array_push($hiddenServices, $hiddenService);
-		file_put_contents("/etc/config/tor/config", @json_encode($hiddenServices, JSON_PRETTY_PRINT));
-		$this->reloadTor();
-	}
+        $hiddenService = array("name" => $name, "forwards" => array() );
+        $hiddenServices = array();
+        if (file_exists("/etc/config/tor/config")) {
+            $hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
+        }
+        array_push($hiddenServices, $hiddenService);
+        file_put_contents("/etc/config/tor/config", @json_encode($hiddenServices, JSON_PRETTY_PRINT));
+        $this->reloadTor();
+    }
 
-	private function removeHiddenService() {
-		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
-		foreach($hiddenServices as $key => $hiddenService) {
-			if($hiddenService->name == $this->request->name) {
-				unset($hiddenServices[$key]);
-			}
-		}
-		file_put_contents("/etc/config/tor/config", @json_encode($hiddenServices, JSON_PRETTY_PRINT));
-		$this->reloadTor();
-	}
-
-
-	private function addServiceForward() {
-		$name = $this->request->name;
-		$port = $this->request->port;
-		$redirect_to = $this->request->redirect_to;
-
-		if(!$this->isValidName($name)) {
-			$this->response = array("error" => "Invalid name"); 
-			return;
-		}
-		if(!$this->isValidPort($port)) {
-			$this->response = array("error" => "Invalid port"); 
-			return;
-		}
-		if(!$this->isValidRedirectTo($redirect_to)) {
-			$this->response = array("error" => "Invalid redirect to"); 
-			return;
-		}
-
-		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
-		foreach($hiddenServices as $key => $hiddenService) {
-			if($hiddenService->name == $name) {
-				$forwards = $hiddenService->forwards;
-				$forward = array("port" => $port, "redirect_to" => $redirect_to);
-				array_push($forwards, $forward);
-				$hiddenServices[$key]->forwards = $forwards;
-			}
-		}
-		file_put_contents("/etc/config/tor/config", @json_encode($hiddenServices, JSON_PRETTY_PRINT));
-
-		$this->reloadTor();	
-	}
-
-	private function removeServiceForward() {
-		$name = $this->request->name;
-		$port = $this->request->port;
-		$redirect_to = $this->request->redirect_to;
-
-		if(!$this->isValidName($name)) {
-			$this->response = array("error" => "Invalid name"); 
-			return;
-		}
-		if(!$this->isValidPort($port)) {
-			$this->response = array("error" => "Invalid port"); 
-			return;
-		}
-		if(!$this->isValidRedirectTo($redirect_to)) {
-			$this->response = array("error" => "Invalid redirect to"); 
-			return;
-		}
+    private function removeHiddenService()
+    {
+        $hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
+        foreach ($hiddenServices as $key => $hiddenService) {
+            if ($hiddenService->name == $this->request->name) {
+                unset($hiddenServices[$key]);
+            }
+        }
+        file_put_contents("/etc/config/tor/config", @json_encode($hiddenServices, JSON_PRETTY_PRINT));
+        $this->reloadTor();
+    }
 
 
-		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
-		foreach($hiddenServices as $hiddenService) {
-			if($hiddenService->name == $name) {
-				$forwards = $hiddenService->forwards;
-				foreach($forwards as $key => $forward) {
-					if($forward->port == $port && $forward->redirect_to == $redirect_to) {
-						unset($forwards[$key]);
-					}
-				}
-				$hiddenService->forwards = $forwards;
-			}
-		}
-		file_put_contents("/etc/config/tor/config", @json_encode($hiddenServices, JSON_PRETTY_PRINT));
+    private function addServiceForward()
+    {
+        $name = $this->request->name;
+        $port = $this->request->port;
+        $redirect_to = $this->request->redirect_to;
 
-		$this->reloadTor();
-	}
+        if (!$this->isValidName($name)) {
+            $this->response = array("error" => "Invalid name");
+            return;
+        }
+        if (!$this->isValidPort($port)) {
+            $this->response = array("error" => "Invalid port");
+            return;
+        }
+        if (!$this->isValidRedirectTo($redirect_to)) {
+            $this->response = array("error" => "Invalid redirect to");
+            return;
+        }
 
+        $hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
+        foreach ($hiddenServices as $key => $hiddenService) {
+            if ($hiddenService->name == $name) {
+                $forwards = $hiddenService->forwards;
+                $forward = array("port" => $port, "redirect_to" => $redirect_to);
+                array_push($forwards, $forward);
+                $hiddenServices[$key]->forwards = $forwards;
+            }
+        }
+        file_put_contents("/etc/config/tor/config", @json_encode($hiddenServices, JSON_PRETTY_PRINT));
+
+        $this->reloadTor();
+    }
+
+    private function removeServiceForward()
+    {
+        $name = $this->request->name;
+        $port = $this->request->port;
+        $redirect_to = $this->request->redirect_to;
+
+        if (!$this->isValidName($name)) {
+            $this->response = array("error" => "Invalid name");
+            return;
+        }
+        if (!$this->isValidPort($port)) {
+            $this->response = array("error" => "Invalid port");
+            return;
+        }
+        if (!$this->isValidRedirectTo($redirect_to)) {
+            $this->response = array("error" => "Invalid redirect to");
+            return;
+        }
+
+
+        $hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
+        foreach ($hiddenServices as $hiddenService) {
+            if ($hiddenService->name == $name) {
+                $forwards = $hiddenService->forwards;
+                foreach ($forwards as $key => $forward) {
+                    if ($forward->port == $port && $forward->redirect_to == $redirect_to) {
+                        unset($forwards[$key]);
+                    }
+                }
+                $hiddenService->forwards = $forwards;
+            }
+        }
+        file_put_contents("/etc/config/tor/config", @json_encode($hiddenServices, JSON_PRETTY_PRINT));
+
+        $this->reloadTor();
+    }
 }

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -150,8 +150,7 @@ class Tor extends Module
 
             $status = "Not running";
             $statusLabel = self::DANGER;
-        }
-        else if (!$this->checkDependency("tor")) {
+        } elseif (!$this->checkDependency("tor")) {
             // TOR is not installed, please install.
             $install = "Not installed";
             $installLabel = self::DANGER;

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -23,6 +23,15 @@ class tor extends Module
 			case 'toggletor':
 				$this->toggletor();
 				break;
+			case 'addHiddenService':
+				$this->addHiddenService();
+				break;
+			case 'removeHiddenService':
+				$this->removeHiddenService();
+			    break;
+			case 'rebindProxy':
+			    $this->rebindProxy();
+				break;
         }
     }
 
@@ -160,4 +169,11 @@ class tor extends Module
 
         $this->response = array("device" => $device, "sdAvailable" => $sdAvailable, "status" => $status, "statusLabel" => $statusLabel, "installed" => $installed, "install" => $install, "installLabel" => $installLabel, "bootLabelON" => $bootLabelON, "bootLabelOFF" => $bootLabelOFF, "processing" => $processing);
     }
+	private function addHiddenService() {
+
+	}
+	private function removeHiddenService() {
+	}
+	private function rebindProxy() {
+	}
 }

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -29,9 +29,6 @@ class tor extends Module
 			case 'removeHiddenService':
 				$this->removeHiddenService();
 			    break;
-			case 'rebindProxy':
-			    $this->rebindProxy();
-				break;
         }
     }
 
@@ -156,7 +153,6 @@ class tor extends Module
 		file_put_contents("/etc/config/tor/config", json_encode($hiddenServices, JSON_PRETTY_PRINT));
 	}
 	private function removeHiddenService() {
-	}
-	private function rebindProxy() {
+		$hiddenServices = @json_decode(file_get_contents("/etc/config/tor/config"));
 	}
 }

--- a/tor/api/module.php
+++ b/tor/api/module.php
@@ -13,6 +13,7 @@ class Tor extends Module
 
     // Display Constants
     const DANGER = 'danger';
+    const WARNING = 'warning';
     const SUCCESS = 'success';
 
     public function route()
@@ -136,65 +137,38 @@ class Tor extends Module
 
         $device = $this->getDevice();
         $sdAvailable = $this->isSDAvailable();
-        $installed = false;
-        $bootLabelON = "default";
-        $bootLabelOFF = self::DANGER;
+        $installed = true;
+        $install = "Installed";
         $processing = false;
 
         if (file_exists($this->progressFile)) {
             // TOR Is installing, please wait.
             $install = "Installing...";
-            $installLabel = "warning";
+            $installed = false;
+            $installLabel = self::WARNING;
             $processing = true;
 
             $status = "Not running";
             $statusLabel = self::DANGER;
-
-            $this->response = array("device" => $device,
-                                    "sdAvailable" => $sdAvailable,
-                                    "status" => $status,
-                                    "statusLabel" => $statusLabel,
-                                    "installed" => $installed,
-                                    "install" => $install,
-                                    "installLabel" => $installLabel,
-                                    "bootLabelON" => $bootLabelON,
-                                    "bootLabelOFF" => $bootLabelOFF,
-                                    "processing" => $processing);
-            return;
         }
-
-        if (!$this->checkDependency("tor")) {
+        else if (!$this->checkDependency("tor")) {
             // TOR is not installed, please install.
             $install = "Not installed";
             $installLabel = self::DANGER;
 
             $status = "Start";
             $statusLabel = self::SUCCESS;
-
-            $this->response = array("device" => $device,
-                                    "sdAvailable" => $sdAvailable,
-                                    "status" => $status,
-                                    "statusLabel" => $statusLabel,
-                                    "installed" => $installed,
-                                    "install" => $install,
-                                    "installLabel" => $installLabel,
-                                    "bootLabelON" => $bootLabelON,
-                                    "bootLabelOFF" => $bootLabelOFF,
-                                    "processing" => $processing);
-            return;
-        }
-
-        // TOR is installed, please configure.
-        $installed = true;
-        $install = "Installed";
-        $installLabel = self::SUCCESS;
-
-        if ($this->checkRunning("tor")) {
-            $status = "Started";
-            $statusLabel = self::SUCCESS;
         } else {
-            $status = "Stopped";
-            $statusLabel = self::DANGER;
+            // TOR is installed, please configure.
+            $installLabel = self::SUCCESS;
+
+            if ($this->checkRunning("tor")) {
+                $status = "Started";
+                $statusLabel = self::SUCCESS;
+            } else {
+                $status = "Stopped";
+                $statusLabel = self::DANGER;
+            }
         }
 
         $this->response = array("device" => $device,
@@ -204,8 +178,6 @@ class Tor extends Module
                                 "installed" => $installed,
                                 "install" => $install,
                                 "installLabel" => $installLabel,
-                                "bootLabelON" => $bootLabelON,
-                                "bootLabelOFF" => $bootLabelOFF,
                                 "processing" => $processing);
     }
 

--- a/tor/files/torrc
+++ b/tor/files/torrc
@@ -1,0 +1,193 @@
+## Configuration file for a typical Tor user
+## Last updated 9 October 2013 for Tor 0.2.5.2-alpha.
+## (may or may not work for much older or much newer versions of Tor.)
+##
+## Lines that begin with "## " try to explain what's going on. Lines
+## that begin with just "#" are disabled commands: you can enable them
+## by removing the "#" symbol.
+##
+## See 'man tor', or https://www.torproject.org/docs/tor-manual.html,
+## for more options you can use in this file.
+##
+## Tor will look for this file in various places based on your platform:
+## https://www.torproject.org/docs/faq#torrc
+
+## Tor opens a socks proxy on port 9050 by default -- even if you don't
+## configure one below. Set "SocksPort 0" if you plan to run Tor only
+## as a relay, and not make any local application connections yourself.
+#SocksPort 9050 # Default: Bind to localhost:9050 for local connections.
+#SocksPort 192.168.0.1:9100 # Bind to this address:port too.
+
+## Entry policies to allow/deny SOCKS requests based on IP address.
+## First entry that matches wins. If no SocksPolicy is set, we accept
+## all (and only) requests that reach a SocksPort. Untrusted users who
+## can access your SocksPort may be able to learn about the connections
+## you make.
+#SocksPolicy accept 192.168.0.0/16
+#SocksPolicy reject *
+
+## Logs go to stdout at level "notice" unless redirected by something
+## else, like one of the below lines. You can have as many Log lines as
+## you want.
+##
+## We advise using "notice" in most cases, since anything more verbose
+## may provide sensitive information to an attacker who obtains the logs.
+##
+## Send all messages of level 'notice' or higher to /var/log/tor/notices.log
+#Log notice file /var/log/tor/notices.log
+## Send every possible message to /var/log/tor/debug.log
+#Log debug file /var/log/tor/debug.log
+## Use the system log instead of Tor's logfiles
+#Log notice syslog
+## To send all messages to stderr:
+#Log debug stderr
+
+## Uncomment this to start the process in the background... or use
+## --runasdaemon 1 on the command line. This is ignored on Windows;
+## see the FAQ entry if you want Tor to run as an NT service.
+RunAsDaemon 1
+
+## The directory for keeping all the keys/etc. By default, we store
+## things in $HOME/.tor on Unix, and in Application Data\tor on Windows.
+DataDirectory /var/lib/tor
+
+## The port on which Tor will listen for local connections from Tor
+## controller applications, as documented in control-spec.txt.
+#ControlPort 9051
+## If you enable the controlport, be sure to enable one of these
+## authentication methods, to prevent attackers from accessing it.
+#HashedControlPassword 16:872860B76453A77D60CA2BB8C1A7042072093276A3D701AD684053EC4C
+#CookieAuthentication 1
+
+############### This section is just for location-hidden services ###
+
+## Once you have configured a hidden service, you can look at the
+## contents of the file ".../hidden_service/hostname" for the address
+## to tell people.
+##
+## HiddenServicePort x y:z says to redirect requests on port x to the
+## address y:z.
+
+#HiddenServiceDir /var/lib/tor/hidden_service/
+#HiddenServicePort 80 127.0.0.1:80
+
+#HiddenServiceDir /var/lib/tor/other_hidden_service/
+#HiddenServicePort 80 127.0.0.1:80
+#HiddenServicePort 22 127.0.0.1:22
+
+################ This section is just for relays #####################
+#
+## See https://www.torproject.org/docs/tor-doc-relay for details.
+
+## Required: what port to advertise for incoming Tor connections.
+#ORPort 9001
+## If you want to listen on a port other than the one advertised in
+## ORPort (e.g. to advertise 443 but bind to 9090), you can do it as
+## follows.  You'll need to do ipchains or other port forwarding
+## yourself to make this work.
+#ORPort 443 NoListen
+#ORPort 127.0.0.1:9090 NoAdvertise
+
+## The IP address or full DNS name for incoming connections to your
+## relay. Leave commented out and Tor will guess.
+#Address noname.example.com
+
+## If you have multiple network interfaces, you can specify one for
+## outgoing traffic to use.
+# OutboundBindAddress 10.0.0.5
+
+## A handle for your relay, so people don't have to refer to it by key.
+#Nickname ididnteditheconfig
+
+## Define these to limit how much relayed traffic you will allow. Your
+## own traffic is still unthrottled. Note that RelayBandwidthRate must
+## be at least 20 KB.
+## Note that units for these config options are bytes per second, not bits
+## per second, and that prefixes are binary prefixes, i.e. 2^10, 2^20, etc.
+#RelayBandwidthRate 100 KB  # Throttle traffic to 100KB/s (800Kbps)
+#RelayBandwidthBurst 200 KB # But allow bursts up to 200KB/s (1600Kbps)
+
+## Use these to restrict the maximum traffic per day, week, or month.
+## Note that this threshold applies separately to sent and received bytes,
+## not to their sum: setting "4 GB" may allow up to 8 GB total before
+## hibernating.
+##
+## Set a maximum of 4 gigabytes each way per period.
+#AccountingMax 4 GB
+## Each period starts daily at midnight (AccountingMax is per day)
+#AccountingStart day 00:00
+## Each period starts on the 3rd of the month at 15:00 (AccountingMax
+## is per month)
+#AccountingStart month 3 15:00
+
+## Administrative contact information for this relay or bridge. This line
+## can be used to contact you if your relay or bridge is misconfigured or
+## something else goes wrong. Note that we archive and publish all
+## descriptors containing these lines and that Google indexes them, so
+## spammers might also collect them. You may want to obscure the fact that
+## it's an email address and/or generate a new address for this purpose.
+#ContactInfo Random Person <nobody AT example dot com>
+## You might also include your PGP or GPG fingerprint if you have one:
+#ContactInfo 0xFFFFFFFF Random Person <nobody AT example dot com>
+
+## Uncomment this to mirror directory information for others. Please do
+## if you have enough bandwidth.
+#DirPort 9030 # what port to advertise for directory connections
+## If you want to listen on a port other than the one advertised in
+## DirPort (e.g. to advertise 80 but bind to 9091), you can do it as
+## follows.  below too. You'll need to do ipchains or other port
+## forwarding yourself to make this work.
+#DirPort 80 NoListen
+#DirPort 127.0.0.1:9091 NoAdvertise
+## Uncomment to return an arbitrary blob of html on your DirPort. Now you
+## can explain what Tor is if anybody wonders why your IP address is
+## contacting them. See contrib/tor-exit-notice.html in Tor's source
+## distribution for a sample.
+#DirPortFrontPage /etc/tor/tor-exit-notice.html
+
+## Uncomment this if you run more than one Tor relay, and add the identity
+## key fingerprint of each Tor relay you control, even if they're on
+## different networks. You declare it here so Tor clients can avoid
+## using more than one of your relays in a single circuit. See
+## https://www.torproject.org/docs/faq#MultipleRelays
+## However, you should never include a bridge's fingerprint here, as it would
+## break its concealability and potentionally reveal its IP/TCP address.
+#MyFamily $keyid,$keyid,...
+
+## A comma-separated list of exit policies. They're considered first
+## to last, and the first match wins. If you want to _replace_
+## the default exit policy, end this with either a reject *:* or an
+## accept *:*. Otherwise, you're _augmenting_ (prepending to) the
+## default exit policy. Leave commented to just use the default, which is
+## described in the man page or at
+## https://www.torproject.org/documentation.html
+##
+## Look at https://www.torproject.org/faq-abuse.html#TypicalAbuses
+## for issues you might encounter if you use the default exit policy.
+##
+## If certain IPs and ports are blocked externally, e.g. by your firewall,
+## you should update your exit policy to reflect this -- otherwise Tor
+## users will be told that those destinations are down.
+##
+## For security, by default Tor rejects connections to private (local)
+## networks, including to your public IP address. See the man page entry
+## for ExitPolicyRejectPrivate if you want to allow "exit enclaving".
+##
+#ExitPolicy accept *:6660-6667,reject *:* # allow irc ports but no more
+#ExitPolicy accept *:119 # accept nntp as well as default exit policy
+#ExitPolicy reject *:* # no exits allowed
+
+## Bridge relays (or "bridges") are Tor relays that aren't listed in the
+## main directory. Since there is no complete public list of them, even an
+## ISP that filters connections to all the known Tor relays probably
+## won't be able to block all the bridges. Also, websites won't treat you
+## differently because they won't know you're running Tor. If you can
+## be a real relay, please do; but if not, be a bridge!
+#BridgeRelay 1
+## By default, Tor will advertise your bridge to users through various
+## mechanisms like https://bridges.torproject.org/. If you want to run
+## a private bridge, for example because you'll give out your bridge
+## address manually to your friends, uncomment this line:
+#PublishServerDescriptor 0
+
+User tor

--- a/tor/js/module.js
+++ b/tor/js/module.js
@@ -75,7 +75,7 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
 		$api.request({
             module: 'tor',
             action: 'handleDependencies',
-						destination: param
+			destination: param
         }, function(response){
             if (response.success === true) {
 				$scope.installLabel = "warning";
@@ -100,4 +100,24 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
 }]);
 
 registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope', '$interval', '$timeout', function($api, $scope, $rootScope, $interval, $timeout) {
+  $scope.refreshHiddenServices = (function() {
+	$api.request({
+		module: 'tor',
+		action: 'refreshHiddenServices'
+	}, function(response) {
+		$scope.hiddenServices = response.hiddenServices;
+	});
+  });
+
+  $scope.addHiddenService = (function() {
+	$api.request({
+		module: 'tor',
+		action: 'addHiddenService',
+		name: $scope.name
+	}, function(response){
+			$scope.hiddenServices = response.hiddenServices;
+			$scope.refreshHiddenServices();
+		});
+    });
+	$scope.refreshHiddenServices();
 }]);

--- a/tor/js/module.js
+++ b/tor/js/module.js
@@ -1,0 +1,120 @@
+registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope', '$interval', '$timeout', function($api, $scope, $rootScope, $interval, $timeout) {
+	$scope.status = "Loading...";
+	$scope.statusLabel = "default";
+	$scope.starting = false;
+
+	$scope.install = "Loading...";
+	$scope.installLabel = "default";
+	$scope.processing = false;
+
+	$scope.bootLabelON = "default";
+	$scope.bootLabelOFF = "default";
+
+	$scope.saveSettingsLabel = "default";
+
+	$scope.device = '';
+	$scope.sdAvailable = false;
+
+	$rootScope.status = {
+		installed : false
+	};
+
+  $scope.refreshStatus = (function() {
+		$api.request({
+            module: "tor",
+            action: "refreshStatus"
+        }, function(response) {
+            $scope.status = response.status;
+			$scope.statusLabel = response.statusLabel;
+
+			$rootScope.status.installed = response.installed;
+			$scope.device = response.device;
+			$scope.sdAvailable = response.sdAvailable;
+			if(response.processing) $scope.processing = true;
+			$scope.install = response.install;
+			$scope.installLabel = response.installLabel;
+
+			$scope.bootLabelON = response.bootLabelON;
+			$scope.bootLabelOFF = response.bootLabelOFF;
+        })
+    });
+
+  $scope.toggletor = (function() {
+		if($scope.status != "Stop")
+			$scope.status = "Starting...";
+		else
+			$scope.status = "Stopping...";
+
+		$scope.statusLabel = "warning";
+		$scope.starting = true;
+
+		$rootScope.status.refreshOutput = false;
+		$rootScope.status.refreshHistory = false;
+
+		$api.request({
+            module: 'tor',
+            action: 'toggletor',
+						interface: $scope.selectedInterface
+        }, function(response) {
+            $timeout(function(){
+							$rootScope.status.refreshOutput = true;
+							$rootScope.status.refreshHistory = true;
+
+	            $scope.starting = false;
+							$scope.refreshStatus();
+            }, 2000);
+        })
+    });
+
+  $scope.toggletorOnBoot = (function() {
+    if($scope.bootLabelON == "default")
+		{
+			$scope.bootLabelON = "success";
+			$scope.bootLabelOFF = "default";
+		}
+		else
+		{
+			$scope.bootLabelON = "default";
+			$scope.bootLabelOFF = "danger";
+		}
+
+		$api.request({
+            module: 'tor',
+            action: 'toggletorOnBoot',
+        }, function(response) {
+			$scope.refreshStatus();
+        })
+    });
+
+  $scope.handleDependencies = (function(param) {
+    if(!$rootScope.status.installed)
+			$scope.install = "Installing...";
+		else
+			$scope.install = "Removing...";
+
+		$api.request({
+            module: 'tor',
+            action: 'handleDependencies',
+						destination: param
+        }, function(response){
+            if (response.success === true) {
+				$scope.installLabel = "warning";
+				$scope.processing = true;
+
+                $scope.handleDependenciesInterval = $interval(function(){
+                    $api.request({
+                        module: 'tor',
+                        action: 'handleDependenciesStatus'
+                    }, function(response) {
+                        if (response.success === true){
+                            $scope.processing = false;
+                            $interval.cancel($scope.handleDependenciesInterval);
+                            $scope.refreshStatus();
+                        }
+                    });
+                }, 5000);
+            }
+        });
+    });
+	$scope.refreshStatus();
+}]);

--- a/tor/js/module.js
+++ b/tor/js/module.js
@@ -51,7 +51,7 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
         }, function(response) {
             $timeout(function(){
 	            $scope.starting = false;
-							$scope.refreshStatus();
+				$scope.refreshStatus();
             }, 2000);
         })
     });
@@ -106,7 +106,7 @@ registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope
 		action: 'addHiddenService',
 		name: $scope.name
 	}, function(response){
-			$scope.refreshHiddenServices();
+		    $scope.refreshHiddenServices();
 		});
     });
 
@@ -116,7 +116,7 @@ registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope
 		action: 'removeHiddenService',
 		name: name
 	}, function(response) {
-			$scope.refreshHiddenServices();
+		    $scope.refreshHiddenServices();
 		});
 	});
 
@@ -128,7 +128,11 @@ registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope
 		port: $scope.port,
 		redirect_to: $scope.redirect_to
 	}, function(response) {
-			$scope.refreshHiddenServices();
+            $scope.hiddenServicesLoad = '(reloading...)';
+            $timeout(function() {
+                $scope.hiddenServicesLoad = '';
+		        $scope.refreshHiddenServices();
+            }, 2000);
 		});
 	});
 
@@ -140,7 +144,11 @@ registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope
 		port: port,
 		redirect_to: redirect_to
 	}, function(response) {
-			$scope.refreshHiddenServices();
+            $scope.hiddenServicesLoad = '(reloading...)';
+            $timeout(function() {
+                $scope.hiddenServicesLoad = '';
+			    $scope.refreshHiddenServices();
+            }, 2000);
 		});
 	});
 

--- a/tor/js/module.js
+++ b/tor/js/module.js
@@ -7,9 +7,6 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
 	$scope.installLabel = "default";
 	$scope.processing = false;
 
-	$scope.bootLabelON = "default";
-	$scope.bootLabelOFF = "default";
-
 	$scope.saveSettingsLabel = "default";
 
 	$scope.device = '';
@@ -33,9 +30,6 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
 			if(response.processing) $scope.processing = true;
 			$scope.install = response.install;
 			$scope.installLabel = response.installLabel;
-
-			$scope.bootLabelON = response.bootLabelON;
-			$scope.bootLabelOFF = response.bootLabelOFF;
         })
     });
 

--- a/tor/js/module.js
+++ b/tor/js/module.js
@@ -100,6 +100,7 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
 }]);
 
 registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope', '$interval', '$timeout', function($api, $scope, $rootScope, $interval, $timeout) {
+
   $scope.refreshHiddenServices = (function() {
 	$api.request({
 		module: 'tor',
@@ -115,9 +116,31 @@ registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope
 		action: 'addHiddenService',
 		name: $scope.name
 	}, function(response){
-			$scope.hiddenServices = response.hiddenServices;
 			$scope.refreshHiddenServices();
 		});
     });
+
+  $scope.removeHiddenService = (function(name) {
+	$api.request({
+		module: 'tor',
+		action: 'removeHiddenService',
+		name: name
+	}, function(response) {
+			$scope.refreshHiddenServices();
+		});
+	});
+
+  $scope.removeServiceForward = (function(name, port, redirect_to) {
+	$api.request({
+		module: 'tor',
+		action: 'removeServiceForward',
+		name: name,
+		port: port,
+		redirect_to: redirect_to
+	}, function(response) {
+			$scope.refreshHiddenServices();
+		});
+	});
+
 	$scope.refreshHiddenServices();
 }]);

--- a/tor/js/module.js
+++ b/tor/js/module.js
@@ -66,26 +66,6 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
         })
     });
 
-  $scope.toggletorOnBoot = (function() {
-    if($scope.bootLabelON == "default")
-		{
-			$scope.bootLabelON = "success";
-			$scope.bootLabelOFF = "default";
-		}
-		else
-		{
-			$scope.bootLabelON = "default";
-			$scope.bootLabelOFF = "danger";
-		}
-
-		$api.request({
-            module: 'tor',
-            action: 'toggletorOnBoot',
-        }, function(response) {
-			$scope.refreshStatus();
-        })
-    });
-
   $scope.handleDependencies = (function(param) {
     if(!$rootScope.status.installed)
 			$scope.install = "Installing...";
@@ -117,4 +97,7 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
         });
     });
 	$scope.refreshStatus();
+}]);
+
+registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope', '$interval', '$timeout', function($api, $scope, $rootScope, $interval, $timeout) {
 }]);

--- a/tor/js/module.js
+++ b/tor/js/module.js
@@ -53,13 +53,9 @@ registerController('tor_DependenciesController', ['$api', '$scope', '$rootScope'
 
 		$api.request({
             module: 'tor',
-            action: 'toggletor',
-						interface: $scope.selectedInterface
+            action: 'toggletor'
         }, function(response) {
             $timeout(function(){
-							$rootScope.status.refreshOutput = true;
-							$rootScope.status.refreshHistory = true;
-
 	            $scope.starting = false;
 							$scope.refreshStatus();
             }, 2000);
@@ -125,6 +121,18 @@ registerController('tor_ConfigurationController', ['$api', '$scope', '$rootScope
 		module: 'tor',
 		action: 'removeHiddenService',
 		name: name
+	}, function(response) {
+			$scope.refreshHiddenServices();
+		});
+	});
+
+  $scope.addServiceForward = (function() {
+	$api.request({
+		module: 'tor',
+		action: 'addServiceForward',
+		name: $scope.name,
+		port: $scope.port,
+		redirect_to: $scope.redirect_to
 	}, function(response) {
 			$scope.refreshHiddenServices();
 		});

--- a/tor/module.html
+++ b/tor/module.html
@@ -66,17 +66,29 @@
 		<div class="panel panel-default" ng-controller="tor_ConfigurationController" ng-show="$root.status.installed">
 			<div class="panel-heading">
 				<h3 class="panel-title">Hidden Services</h3>
+				{{ config }}
 			</div>
 
 			<div class="panel-body">
 				<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addHiddenService" ng-disabled="processing">Add Service</button>
 				<div ng-repeat="service in hiddenServices">
-					{{ service.name }}
-					<button type="button" class="btn btn-info btn-xs" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
-					<div ng-repeat="forward in service.forwards">
-						<button type="button" class="btn btn-danger btn-xs" data-toggle="modal" data-target="#removeServiceForward" ng-disabled="processing">Delete</button>
-						Forwarding {{ forward.port }} to {{ forward.redirect_to }}
-					</div><br/>
+					<h4>
+						{{ service.name }} <span ng-show="service.hostname">(<a href="http://{{service.hostname}}">{{service.hostname}}</a>)</span>
+						<button type="button" class="btn btn-danger btn-xs pull-right" data-toggle="modal" ng-click="removeHiddenService(service.name)" ng-disabled="processing">Remove Service</button>
+					</h4>
+					<div>
+						<table style="width: 100%">
+							<th>Port</th>
+							<th>Redirect to</th>
+							<th></th>
+							<tr ng-repeat="forward in service.forwards">
+								<td>{{ forward.port }}</td>
+								<td>{{ forward.redirect_to }}</td>
+								<td style="text-align:right;padding-bottom: .5em;"><button type="button" class="btn btn-danger btn-xs" data-toggle="modal" data-target="#removeServiceForward" ng-click="removeServiceForward(service.name, forward.port, forward.redirect_to);" ng-disabled="processing" aria-label="Delete Forward">X</button></td>
+							</tr>
+						</table>
+						<button type="button" class="btn btn-info btn-xs" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
+					</div>
 				</div>
 			</div>
 
@@ -117,7 +129,7 @@
 									<td><input type="text" class="form-control" placeholder="80" ng-model="port"></td>
 								</tr>
 								<tr>
-									<td style="padding-bottom: .5em;" class="text-muted">Port:</td>
+									<td style="padding-bottom: .5em;" class="text-muted">Redirect to:</td>
 									<td><input type="text" class="form-control" placeholder="127.0.0.1:1471" ng-model="redirect_to"></td>
 								</tr>
 							</table>

--- a/tor/module.html
+++ b/tor/module.html
@@ -52,7 +52,7 @@
 						</div>
 					<div class="modal-body">
 						All required dependencies will be removed. This may take a few minutes.<br /><br />
-						Please wait, do not leave or refresh this page. Once the remove is complete, this page will refresh automatically.
+						<input type="text" class="form-control" placeholder="365">Please wait, do not leave or refresh this page. Once the remove is complete, this page will refresh automatically.
 					</div>
 					<div class="modal-footer">
 						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
@@ -66,8 +66,43 @@
 		<div class="panel-heading">
 			<h3 class="panel-title">Configuration</h3>
 			<div class="panel-body">
-			{{ message }}
+				<table style="width:100%">
+					<tr style="padding-bottom: .5em;" class="text-muted">
+						<td>SocksPort: {{message}}</td>
+						<td>
+					</tr>
+				</table>
 			</div>
 		</div>		
+		<div class="panel-heading">
+				<h3 class="panel-title">Hidden Services</h3>
+			</div>
+			<div class="panel-body">
+				<button type="button" class="btn btn-success btn-xs" data-toggle="modal" data-target="#addHiddenService" ng-disabled="processing">Add Hidden Servce</button>
+			</div>
+			<div class="modal fade" id="addHiddenService" tabindex="-1" role="dialog" aria-labelledby="addHiddenServiceLabel">
+				<div class="modal-dialog" role="document">
+					<div class="modal-content">
+						<div class="modal-header">
+							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+							<h4 class="modal-title" id="addHiddenServiceRemoveModalLabel">Add Hidden Service</h4>
+						</div>
+					<div class="modal-body">
+						<table style="width: 100%">
+							<tr>
+								<td style="padding-bottom: .5em;" class="text-muted">Directory:</td>
+								<td>
+									<input type="text" class="form-control" placeholder="/var/lib/tor/hidden_service" ng-model="directory">
+								</td>
+							</tr>
+						</table>
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+						<button type="button" class="btn btn-info" ng-click="addHiddenService()" data-dismiss="modal">Add Service</button>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
 </div>

--- a/tor/module.html
+++ b/tor/module.html
@@ -21,15 +21,6 @@
 							<button type="button" style="width: 90px;" class="btn btn-{{statusLabel}} btn-xs" ng-disabled="starting" ng-click="toggletor()">{{status}}</button>
 						</td>
 					</tr>
-					<tr ng-show="$root.status.installed">
-						<td style="padding-bottom: .5em;" class="text-muted">Start on boot</td>
-						<td style="text-align:right;padding-bottom: .5em;">
-							<div class="btn-group">
-								<button ng-click="toggletorOnBoot()" class="btn btn-xs btn-{{bootLabelON}}">ON</button>
-								<button ng-click="toggletorOnBoot()" class="btn btn-xs btn-{{bootLabelOFF}}">OFF</button>
-							</div>
-						</td>
-					</tr>
 				</table>
 			</div>
 
@@ -45,7 +36,7 @@
 							Please wait, do not leave or refresh this page. Once the install is complete, this page will refresh automatically.
 						</div>
 						<div class="modal-footer">
-							<button type="button" class="btn btn-info" ng-click="handleDependencies('internal')" data-dismiss="modal">Internal</button>
+							<button type="button" class="btn btn-info" ng-hide="device == 'nano'" ng-click="handleDependencies('internal')" data-dismiss="modal">Internal</button>
 							<button type="button" class="btn btn-info" ng-hide="device == 'tetra' || sdAvailable == false" ng-click="handleDependencies('sd')" data-dismiss="modal">SD Card</button>
 						</div>
 					</div>
@@ -70,5 +61,13 @@
 				</div>
 			</div>
 		</div>
+	</div>
+	<div class="panel panel-default" ng-controller="tor_ConfigurationController" ng-show="$root.status.installed">
+		<div class="panel-heading">
+			<h3 class="panel-title">Configuration</h3>
+			<div class="panel-body">
+			{{ message }}
+			</div>
+		</div>		
 	</div>
 </div>

--- a/tor/module.html
+++ b/tor/module.html
@@ -78,7 +78,8 @@
 				<h3 class="panel-title">Hidden Services</h3>
 			</div>
 			<div class="panel-body">
-				<button type="button" class="btn btn-success btn-xs" data-toggle="modal" data-target="#addHiddenService" ng-disabled="processing">Add Hidden Servce</button>
+				<button type="button" class="btn btn-success btn-xs" data-toggle="modal" data-target="#addHiddenService" ng-disabled="processing">Add Hidden Service</button>
+				{{ config }}
 			</div>
 			<div class="modal fade" id="addHiddenService" tabindex="-1" role="dialog" aria-labelledby="addHiddenServiceLabel">
 				<div class="modal-dialog" role="document">

--- a/tor/module.html
+++ b/tor/module.html
@@ -71,7 +71,7 @@
 
 			<div class="panel-body">
 				<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addHiddenService" ng-disabled="processing">Add Service</button>
-				<button type="button" class="btn btn-info" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
+				<button type="button" class="btn btn-info" ng-show="hiddenServices.length > 0" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
 				<div ng-repeat="service in hiddenServices">
 					<h4>
 						<span class="col-md-4">{{ service.name }}</span>

--- a/tor/module.html
+++ b/tor/module.html
@@ -52,7 +52,7 @@
 						</div>
 						<div class="modal-body">
 							All required dependencies will be removed. This may take a few minutes.<br /><br />
-							<input type="text" class="form-control" placeholder="365">Please wait, do not leave or refresh this page. Once the remove is complete, this page will refresh automatically.
+							Please wait, do not leave or refresh this page. Once the remove is complete, this page will refresh automatically.
 						</div>
 						<div class="modal-footer">
 							<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
@@ -74,8 +74,11 @@
 				<button type="button" class="btn btn-info" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
 				<div ng-repeat="service in hiddenServices">
 					<h4>
-						{{ service.name }} <span ng-show="service.hostname">(<a href="http://{{service.hostname}}">{{service.hostname}}</a>)</span>
-						<button type="button" class="btn btn-danger btn-xs pull-right" data-toggle="modal" ng-click="removeHiddenService(service.name)" ng-disabled="processing">Remove Service</button>
+						<span class="col-md-4">{{ service.name }}</span>
+						<span class="col-md-4" ng-show="service.hostname">(<a href="http://{{service.hostname}}">{{service.hostname}}</a>)</span>
+						<span class="col-md-4">
+							<button type="button" class="btn btn-danger btn-xs pull-right" data-toggle="modal" ng-click="removeHiddenService(service.name)" ng-disabled="processing">Remove Service</button>
+						</span>
 					</h4>
 					<div>
 						<table style="width: 100%">

--- a/tor/module.html
+++ b/tor/module.html
@@ -36,7 +36,7 @@
 							Please wait, do not leave or refresh this page. Once the install is complete, this page will refresh automatically.
 						</div>
 						<div class="modal-footer">
-							<button type="button" class="btn btn-info" ng-hide="device == 'nano'" ng-click="handleDependencies('internal')" data-dismiss="modal">Internal</button>
+							<button type="button" class="btn btn-info" ng-click="handleDependencies('internal')" data-dismiss="modal">Internal</button>
 							<button type="button" class="btn btn-info" ng-hide="device == 'tetra' || sdAvailable == false" ng-click="handleDependencies('sd')" data-dismiss="modal">SD Card</button>
 						</div>
 					</div>

--- a/tor/module.html
+++ b/tor/module.html
@@ -71,6 +71,7 @@
 
 			<div class="panel-body">
 				<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addHiddenService" ng-disabled="processing">Add Service</button>
+				<button type="button" class="btn btn-info" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
 				<div ng-repeat="service in hiddenServices">
 					<h4>
 						{{ service.name }} <span ng-show="service.hostname">(<a href="http://{{service.hostname}}">{{service.hostname}}</a>)</span>
@@ -87,7 +88,6 @@
 								<td style="text-align:right;padding-bottom: .5em;"><button type="button" class="btn btn-danger btn-xs" data-toggle="modal" data-target="#removeServiceForward" ng-click="removeServiceForward(service.name, forward.port, forward.redirect_to);" ng-disabled="processing" aria-label="Delete Forward">X</button></td>
 							</tr>
 						</table>
-						<button type="button" class="btn btn-info btn-xs" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
 					</div>
 				</div>
 			</div>
@@ -114,30 +114,36 @@
 					</div>
 				</div>
 			</div>
-
 			<div class="modal fade" id="addServiceForward" tabindex="-1" role="dialog" aria-labelledby="addServiceForwardLabel">
 				<div class="modal-dialog" role="document">
 					<div class="modal-content">
 						<div class="modal-header">
-							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-							<h4 class="modal-title" id="addServiceForwardRemoveModalLabel">Add Forward to Service</h4>
-						</div>
-						<div class="modal-body">
-							<table style="width: 100%">
-								<tr>
-									<td style="padding-bottom: .5em;" class="text-muted">Port:</td>
-									<td><input type="text" class="form-control" placeholder="80" ng-model="port"></td>
-								</tr>
-								<tr>
-									<td style="padding-bottom: .5em;" class="text-muted">Redirect to:</td>
-									<td><input type="text" class="form-control" placeholder="127.0.0.1:1471" ng-model="redirect_to"></td>
-								</tr>
-							</table>
-						</div>
-						<div class="modal-footer">
-							<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-							<button type="button" class="btn btn-info" ng-click="addServiceForward()" data-dismiss="modal">Add Forward</button>
-						</div>
+						<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+						<h4 class="modal-title" id="addServiceForwardRemoveModalLabel">Add Forward to Service</h4>
+					</div>
+					<div class="modal-body">
+						<table style="width: 100%">
+							<tr>
+								<td>Service:</td>
+								<td style="padding-bottom: .5em">
+									<select ng-model="name">
+										<option ng-repeat="service in hiddenServices">{{service.name}}</option>
+									</select>
+								</td>
+							</tr>
+							<tr>
+								<td style="padding-bottom: .5em;" class="text-muted">Port:</td>
+								<td><input type="text" class="form-control" placeholder="80" ng-model="port"></td>
+							</tr>
+							<tr>
+								<td style="padding-bottom: .5em;" class="text-muted">Redirect to:</td>
+								<td><input type="text" class="form-control" placeholder="127.0.0.1:1471" ng-model="redirect_to"></td>
+							</tr>
+						</table>
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+						<button type="button" class="btn btn-info" ng-click="addServiceForward()" data-dismiss="modal">Add Forward</button>
 					</div>
 				</div>
 			</div>

--- a/tor/module.html
+++ b/tor/module.html
@@ -29,7 +29,7 @@
 					<div class="modal-content">
 						<div class="modal-header">
 							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-							<h4 class="modal-title" id="dependenciesInstallModalLabel">Install dependencies</h4>
+								<h4 class="modal-title" id="dependenciesInstallModalLabel">Install dependencies</h4>
 						</div>
 						<div class="modal-body">
 							All required dependencies have to be installed first. This may take a few minutes.<br /><br />
@@ -50,37 +50,36 @@
 							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 							<h4 class="modal-title" id="dependenciesRemoveModalLabel">Remove dependencies</h4>
 						</div>
-					<div class="modal-body">
-						All required dependencies will be removed. This may take a few minutes.<br /><br />
-						<input type="text" class="form-control" placeholder="365">Please wait, do not leave or refresh this page. Once the remove is complete, this page will refresh automatically.
-					</div>
-					<div class="modal-footer">
-						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-						<button type="button" class="btn btn-info" ng-click="handleDependencies()" data-dismiss="modal">Confirm</button>
+						<div class="modal-body">
+							All required dependencies will be removed. This may take a few minutes.<br /><br />
+							<input type="text" class="form-control" placeholder="365">Please wait, do not leave or refresh this page. Once the remove is complete, this page will refresh automatically.
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+							<button type="button" class="btn btn-info" ng-click="handleDependencies()" data-dismiss="modal">Confirm</button>
+						</div>
 					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-	<div class="panel panel-default" ng-controller="tor_ConfigurationController" ng-show="$root.status.installed">
-		<div class="panel-heading">
-			<h3 class="panel-title">Configuration</h3>
-			<div class="panel-body">
-				<table style="width:100%">
-					<tr style="padding-bottom: .5em;" class="text-muted">
-						<td>SocksPort: {{message}}</td>
-						<td>
-					</tr>
-				</table>
-			</div>
-		</div>		
-		<div class="panel-heading">
+
+		<div class="panel panel-default" ng-controller="tor_ConfigurationController" ng-show="$root.status.installed">
+			<div class="panel-heading">
 				<h3 class="panel-title">Hidden Services</h3>
 			</div>
+
 			<div class="panel-body">
-				<button type="button" class="btn btn-success btn-xs" data-toggle="modal" data-target="#addHiddenService" ng-disabled="processing">Add Hidden Service</button>
-				{{ config }}
+				<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addHiddenService" ng-disabled="processing">Add Service</button>
+				<div ng-repeat="service in hiddenServices">
+					{{ service.name }}
+					<button type="button" class="btn btn-info btn-xs" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
+					<div ng-repeat="forward in service.forwards">
+						<button type="button" class="btn btn-danger btn-xs" data-toggle="modal" data-target="#removeServiceForward" ng-disabled="processing">Delete</button>
+						Forwarding {{ forward.port }} to {{ forward.redirect_to }}
+					</div><br/>
+				</div>
 			</div>
+
 			<div class="modal fade" id="addHiddenService" tabindex="-1" role="dialog" aria-labelledby="addHiddenServiceLabel">
 				<div class="modal-dialog" role="document">
 					<div class="modal-content">
@@ -88,19 +87,45 @@
 							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 							<h4 class="modal-title" id="addHiddenServiceRemoveModalLabel">Add Hidden Service</h4>
 						</div>
-					<div class="modal-body">
-						<table style="width: 100%">
-							<tr>
-								<td style="padding-bottom: .5em;" class="text-muted">Directory:</td>
-								<td>
-									<input type="text" class="form-control" placeholder="/var/lib/tor/hidden_service" ng-model="directory">
-								</td>
-							</tr>
-						</table>
+						<div class="modal-body">
+							<table style="width: 100%">
+								<tr>
+									<td style="padding-bottom: .5em;" class="text-muted">Directory:</td>
+									<td><input type="text" class="form-control" placeholder="hidden_service" ng-model="name"></td>
+								</tr>
+							</table>
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+							<button type="button" class="btn btn-info" ng-click="addHiddenService()" data-dismiss="modal">Add Service</button>
+						</div>
 					</div>
-					<div class="modal-footer">
-						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-						<button type="button" class="btn btn-info" ng-click="addHiddenService()" data-dismiss="modal">Add Service</button>
+				</div>
+			</div>
+
+			<div class="modal fade" id="addServiceForward" tabindex="-1" role="dialog" aria-labelledby="addServiceForwardLabel">
+				<div class="modal-dialog" role="document">
+					<div class="modal-content">
+						<div class="modal-header">
+							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+							<h4 class="modal-title" id="addServiceForwardRemoveModalLabel">Add Forward to Service</h4>
+						</div>
+						<div class="modal-body">
+							<table style="width: 100%">
+								<tr>
+									<td style="padding-bottom: .5em;" class="text-muted">Port:</td>
+									<td><input type="text" class="form-control" placeholder="80" ng-model="port"></td>
+								</tr>
+								<tr>
+									<td style="padding-bottom: .5em;" class="text-muted">Port:</td>
+									<td><input type="text" class="form-control" placeholder="127.0.0.1:1471" ng-model="redirect_to"></td>
+								</tr>
+							</table>
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+							<button type="button" class="btn btn-info" ng-click="addServiceForward()" data-dismiss="modal">Add Forward</button>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/tor/module.html
+++ b/tor/module.html
@@ -1,0 +1,74 @@
+<div class="row">
+	<div class="col-md-4">
+		<div class="panel panel-default" ng-controller="tor_DependenciesController">
+			<div class="panel-heading">
+				<h3 class="panel-title">Dependencies</h3>
+			</div>
+			<div class="panel-body">
+				<table style="width:100%">
+					<tr>
+						<td style="padding-bottom: .5em;" class="text-muted">Dependencies</td>
+						<td ng-hide="$root.status.installed" style="text-align:right;padding-bottom: .5em;">
+							<button type="button" style="width: 90px;" class="btn btn-{{installLabel}} btn-xs" data-toggle="modal" data-target="#dependenciesInstallModal" ng-disabled="processing">{{install}}</button>
+						</td>
+						<td ng-show="$root.status.installed" style="text-align:right;padding-bottom: .5em;">
+							<button type="button" style="width: 90px;" class="btn btn-{{installLabel}} btn-xs" data-toggle="modal" data-target="#dependenciesRemoveModal" ng-disabled="processing">{{install}}</button>
+						</td>
+					</tr>
+					<tr class="form-inline" ng-show="$root.status.installed">
+						<td style="padding-bottom: .5em;" class="text-muted">tor</td>
+						<td style="text-align:right;padding-bottom: .5em;">
+							<button type="button" style="width: 90px;" class="btn btn-{{statusLabel}} btn-xs" ng-disabled="starting" ng-click="toggletor()">{{status}}</button>
+						</td>
+					</tr>
+					<tr ng-show="$root.status.installed">
+						<td style="padding-bottom: .5em;" class="text-muted">Start on boot</td>
+						<td style="text-align:right;padding-bottom: .5em;">
+							<div class="btn-group">
+								<button ng-click="toggletorOnBoot()" class="btn btn-xs btn-{{bootLabelON}}">ON</button>
+								<button ng-click="toggletorOnBoot()" class="btn btn-xs btn-{{bootLabelOFF}}">OFF</button>
+							</div>
+						</td>
+					</tr>
+				</table>
+			</div>
+
+			<div class="modal fade" id="dependenciesInstallModal" tabindex="-1" role="dialog" aria-labelledby="dependenciesModalLabel">
+				<div class="modal-dialog" role="document">
+					<div class="modal-content">
+						<div class="modal-header">
+							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+							<h4 class="modal-title" id="dependenciesInstallModalLabel">Install dependencies</h4>
+						</div>
+						<div class="modal-body">
+							All required dependencies have to be installed first. This may take a few minutes.<br /><br />
+							Please wait, do not leave or refresh this page. Once the install is complete, this page will refresh automatically.
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-info" ng-click="handleDependencies('internal')" data-dismiss="modal">Internal</button>
+							<button type="button" class="btn btn-info" ng-hide="device == 'tetra' || sdAvailable == false" ng-click="handleDependencies('sd')" data-dismiss="modal">SD Card</button>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="modal fade" id="dependenciesRemoveModal" tabindex="-1" role="dialog" aria-labelledby="dependenciesModalLabel">
+				<div class="modal-dialog" role="document">
+					<div class="modal-content">
+						<div class="modal-header">
+							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+							<h4 class="modal-title" id="dependenciesRemoveModalLabel">Remove dependencies</h4>
+						</div>
+					<div class="modal-body">
+						All required dependencies will be removed. This may take a few minutes.<br /><br />
+						Please wait, do not leave or refresh this page. Once the remove is complete, this page will refresh automatically.
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+						<button type="button" class="btn btn-info" ng-click="handleDependencies()" data-dismiss="modal">Confirm</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/tor/module.html
+++ b/tor/module.html
@@ -68,7 +68,7 @@
 	<div class="col-md-8">
 		<div class="panel panel-default" ng-controller="tor_ConfigurationController" ng-show="$root.status.installed">
 			<div class="panel-heading">
-				<h3 class="panel-title">Hidden Services</h3>
+                <h3 class="panel-title">Hidden Services {{ hiddenServicesLoad }}</h3>
 				{{ config }}
 			</div>
 

--- a/tor/module.html
+++ b/tor/module.html
@@ -62,7 +62,10 @@
 				</div>
 			</div>
 		</div>
-
+        </div>
+</div>
+<div class="row">
+	<div class="col-md-8">
 		<div class="panel panel-default" ng-controller="tor_ConfigurationController" ng-show="$root.status.installed">
 			<div class="panel-heading">
 				<h3 class="panel-title">Hidden Services</h3>
@@ -74,9 +77,9 @@
 				<button type="button" class="btn btn-info" ng-show="hiddenServices.length > 0" data-toggle="modal" data-target="#addServiceForward" ng-disabled="processing">Add Forward</button>
 				<div ng-repeat="service in hiddenServices">
 					<h4>
-						<span class="col-md-4">{{ service.name }}</span>
-						<span class="col-md-4" ng-show="service.hostname">(<a href="http://{{service.hostname}}">{{service.hostname}}</a>)</span>
-						<span class="col-md-4">
+						<span>{{ service.name }}</span>
+						<span ng-show="service.hostname">(<a href="http://{{service.hostname}}">{{service.hostname}}</a>)</span>
+						<span>
 							<button type="button" class="btn btn-danger btn-xs pull-right" data-toggle="modal" ng-click="removeHiddenService(service.name)" ng-disabled="processing">Remove Service</button>
 						</span>
 					</h4>

--- a/tor/module.info
+++ b/tor/module.info
@@ -1,0 +1,7 @@
+{
+    "author":"catatonicprime",
+    "description":"Connect device to tor network, manage hidden services, etc.",
+    "devices": [ "nano", "tetra" ],
+    "title":"tor",
+    "version":"1.0"
+}

--- a/tor/module.info
+++ b/tor/module.info
@@ -1,7 +1,7 @@
 {
     "author":"catatonicprime",
     "description":"Connect device to tor network, manage hidden services, etc.",
-    "devices": [ "tetra" ],
+    "devices": [ "nano", "tetra" ],
     "title":"tor",
     "version":"1.0"
 }

--- a/tor/module.info
+++ b/tor/module.info
@@ -1,7 +1,7 @@
 {
     "author":"catatonicprime",
     "description":"Connect device to tor network, manage hidden services, etc.",
-    "devices": [ "nano", "tetra" ],
+    "devices": [ "tetra" ],
     "title":"tor",
     "version":"1.0"
 }

--- a/tor/scripts/autostart_tor.sh
+++ b/tor/scripts/autostart_tor.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-# author: catatonicprime
-# date: March 2018
-
-/etc/init.d/tor start

--- a/tor/scripts/autostart_tor.sh
+++ b/tor/scripts/autostart_tor.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# author: catatonicprime
+# date: March 2018
+
+/etc/init.d/tor start

--- a/tor/scripts/dependencies.sh
+++ b/tor/scripts/dependencies.sh
@@ -18,6 +18,8 @@ if [ "$1" = "install" ]; then
   cp /pineapple/modules/tor/files/torrc /etc/config/tor
   mkdir -p /etc/config/tor/services
   chown tor:tor /etc/config/tor/services
+  chown root:tor /etc/tor/torrc
+  chmod g+r /etc/tor/torrc
 elif [ "$1" = "remove" ]; then
     opkg remove tor-geoip tor
     sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local

--- a/tor/scripts/dependencies.sh
+++ b/tor/scripts/dependencies.sh
@@ -13,8 +13,8 @@ if [ "$1" = "install" ]; then
   fi
   mkdir -p /etc/config/tor/
   cp /pineapple/modules/tor/files/torrc /etc/config/tor
-  mkdir -p /var/lib/tor/services
-  chown tor:tor /var/lib/tor/services
+  mkdir -p /etc/config/tor/services
+  chown tor:tor /etc/config/tor/services
 elif [ "$1" = "remove" ]; then
     opkg remove tor
 	sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local

--- a/tor/scripts/dependencies.sh
+++ b/tor/scripts/dependencies.sh
@@ -2,23 +2,26 @@
 # author: catatonicprime
 # date: March 2018
 
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/sd/lib:/sd/usr/lib
+export PATH=$PATH:/sd/usr/bin:/sd/usr/sbin
+
 touch /tmp/tor.progress
 
 if [ "$1" = "install" ]; then
   opkg update
   if [ "$2" = "internal" ]; then
-    opkg install tor
+    opkg install tor-geoip tor
   elif [ "$2" = "sd" ]; then
-    opkg install tor --dest sd
+    opkg install tor-geoip tor --dest sd
   fi
   mkdir -p /etc/config/tor/
   cp /pineapple/modules/tor/files/torrc /etc/config/tor
   mkdir -p /etc/config/tor/services
   chown tor:tor /etc/config/tor/services
 elif [ "$1" = "remove" ]; then
-    opkg remove tor
-	sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local
-	rm -rf /etc/config/tor
+    opkg remove tor-geoip tor
+    sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local
+    rm -rf /etc/config/tor
 fi
 
 rm /tmp/tor.progress

--- a/tor/scripts/dependencies.sh
+++ b/tor/scripts/dependencies.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# author: catatonicprime
+# date: March 2018
+
+pkg=tor
+
+touch /tmp/$pkg.progress
+
+if [ "$1" = "install" ]; then
+  opkg update
+  if [ "$2" = "internal" ]; then
+    opkg install $pkg
+  elif [ "$2" = "sd" ]; then
+    opkg install $pkg --dest sd
+  fi
+elif [ "$1" = "remove" ]; then
+    opkg remove $pkg
+	sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local
+fi
+
+rm /tmp/$pkg.progress

--- a/tor/scripts/dependencies.sh
+++ b/tor/scripts/dependencies.sh
@@ -2,20 +2,21 @@
 # author: catatonicprime
 # date: March 2018
 
-pkg=tor
-
-touch /tmp/$pkg.progress
+touch /tmp/tor.progress
 
 if [ "$1" = "install" ]; then
   opkg update
   if [ "$2" = "internal" ]; then
-    opkg install $pkg
+    opkg install tor
   elif [ "$2" = "sd" ]; then
-    opkg install $pkg --dest sd
+    opkg install tor --dest sd
   fi
+  mkdir -p /etc/config/tor/
+  cp /pineapple/modules/tor/files/torrc /etc/config/tor
 elif [ "$1" = "remove" ]; then
-    opkg remove $pkg
+    opkg remove tor
 	sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local
+	rm -rf /etc/config/tor
 fi
 
-rm /tmp/$pkg.progress
+rm /tmp/tor.progress

--- a/tor/scripts/dependencies.sh
+++ b/tor/scripts/dependencies.sh
@@ -13,6 +13,8 @@ if [ "$1" = "install" ]; then
   fi
   mkdir -p /etc/config/tor/
   cp /pineapple/modules/tor/files/torrc /etc/config/tor
+  mkdir -p /var/lib/tor/services
+  chown tor:tor /var/lib/tor/services
 elif [ "$1" = "remove" ]; then
     opkg remove tor
 	sed -i '/tor\/scripts\/autostart_tor.sh/d' /etc/rc.local


### PR DESCRIPTION
Creating TOR management module. This module provides the following functionality:

- Install/remove tor package
- Add/remove hidden services
- Add/remove port forwards for each hidden service

This means the tetra becomes effective at "NAT punching" & creates a unique opportunity to improve the anonymity of the manager/tester by providing a TOR backdoor into the connected network. 

Suggested use-cases are:
- Create management hidden service by forwarding 80 to 127.0.0.1:1471 and use TOR browser to manage .onion.
- Create SSH management hidden service by forwarding 22 to 127.0.0.1:22 and use torify + ssh to manage .onion.
- Create port forwarding pivots by forwarding ports to remote hosts and use torify/proxychains to perform pivoting attacks.

Known issues & areas I'd already like to see additional improvements.
- no input validation in the front-end
- input validation in the backend is rudimentary regex and possibly overly strict when present
- missing service:port in use check minor bug, will fix in the future
- Needs additional documentation
- I wrote it