### PR TITLE
create capture dir, and parse json response

### DIFF
--- a/SiteSurvey/js/module.js
+++ b/SiteSurvey/js/module.js
@@ -438,7 +438,7 @@ registerController('SiteSurvey_CaptureController', ['$api', '$scope', '$rootScop
             module: "SiteSurvey",
             action: "refreshCapture"
         }, function(response) {
-                $scope.capture = JSON.parse(response.replace(/\)\]\}\',\ntrue/, ''));
+                $scope.capture = response;
         })
     });
 

--- a/SiteSurvey/js/module.js
+++ b/SiteSurvey/js/module.js
@@ -438,7 +438,7 @@ registerController('SiteSurvey_CaptureController', ['$api', '$scope', '$rootScop
             module: "SiteSurvey",
             action: "refreshCapture"
         }, function(response) {
-                $scope.capture = response;
+                $scope.capture = JSON.parse(response.replace(/\)\]\}\',\ntrue/, ''));
         })
     });
 

--- a/SiteSurvey/module.info
+++ b/SiteSurvey/module.info
@@ -6,5 +6,5 @@
         "tetra"
     ],
     "title": "Site Survey",
-    "version": "1.3"
+    "version": "1.4"
 }

--- a/SiteSurvey/scripts/capture.sh
+++ b/SiteSurvey/scripts/capture.sh
@@ -55,6 +55,11 @@ if [ "$1" = "start" ]; then
 
   echo ${BSSID} > ${LOCK}
 
+  # make sure the folder exists
+  if [ ! -d /pineapple/modules/SiteSurvey/capture ]; then
+    mkdir /pineapple/modules/SiteSurvey/capture
+  fi
+
   airodump-ng -c ${CHANNEL} --bssid ${BSSID} -w /pineapple/modules/SiteSurvey/capture/capture_${MYTIME} ${MYMONITOR} &> /dev/null &
 
   echo -e "Capture is running..." >> ${LOG}

--- a/SiteSurvey/scripts/dependencies.sh
+++ b/SiteSurvey/scripts/dependencies.sh
@@ -23,6 +23,8 @@ if [ "$1" = "install" ]; then
   uci set sitesurvey.module.installed=1
   uci commit sitesurvey.module.installed
 
+  mkdir /pineapple/modules/SiteSurvey/capture
+
 elif [ "$1" = "remove" ]; then
     rm -rf /etc/config/sitesurvey
 fi


### PR DESCRIPTION
When streamfunction is used, the json response is not automatically
parsed. I bet there is a better way to do this.

Fixes #23 

Should we add the capture dir to git with a .keep file?
I feel like the JSON.parse is addressing the symptom, not the problem. I looked at a few other modules using streamFunction, and they all seemed broken. I imagine there is a better place to put that JSON.parse, but all I have is the minified js. Is there some place that code lives publicly?