### PR TITLE
fixed default install script for tcpdump

### DIFF
--- a/tcpdump/module.info
+++ b/tcpdump/module.info
@@ -6,5 +6,5 @@
         "tetra"
     ],
     "title": "tcpdump",
-    "version": "1.5"
+    "version": "1.5.1"
 }

--- a/tcpdump/module.info
+++ b/tcpdump/module.info
@@ -6,5 +6,5 @@
         "tetra"
     ],
     "title": "tcpdump",
-    "version": "1.5.1"
+    "version": "1.6"
 }

--- a/tcpdump/scripts/tcpdump.sh
+++ b/tcpdump/scripts/tcpdump.sh
@@ -5,7 +5,16 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/sd/lib:/sd/usr/lib
 export PATH=$PATH:/sd/usr/bin:/sd/usr/sbin
 
 MYTIME=`date +%s`
-MYCMD=`cat /tmp/tcpdump.run`
+MYCMD="tcpdump `cat /tmp/tcpdump.run`"
+DUMPPATH='/pineapple/modules/tcpdump/dump/'
+
+echo "Starting if"
+if [ ! -d "$DUMPPATH" ]; then
+  # Control will enter here if $DUMPPATH doesn't exist.
+  # Recursively make the path
+  mkdir -p "$DUMPPATH"
+fi
+
 
 if [ "$1" = "start" ]; then
 	eval ${MYCMD}


### PR DESCRIPTION
The default install does not work on my nano. I did a search and found on your forums a manual fix folks are doing:
https://forums.hak5.org/topic/42983-tcpdump-error-at-start-with-default-settings/?tab=comments#comment-304453

I modified the script to make the dump folder if it does not exist and added tcpdump to MYCMD