### PR TITLE
Site Survey displaying a loading gif when downloading handshakes

### DIFF
--- a/SiteSurvey/js/module.js
+++ b/SiteSurvey/js/module.js
@@ -432,6 +432,7 @@ registerController('SiteSurvey_CaptureController', ['$api', '$scope', '$rootScop
 	$scope.capture = [];
 	$scope.captureOutput = 'Loading...';
 	$scope.captureDate = 'Loading...';
+	$scope.throbber = false;
 
   $scope.refreshCapture = (function() {
         $api.request({
@@ -464,11 +465,13 @@ registerController('SiteSurvey_CaptureController', ['$api', '$scope', '$rootScop
     });
 
 	$scope.downloadCapture = (function(param) {
+	        $scope.throbber = true;
 				$api.request({
             module: 'SiteSurvey',
             action: 'downloadCapture',
 						file: param
         }, function(response) {
+	    $scope.throbber = false;
             if (response.error === undefined) {
                 window.location = '/api/?download=' + response.download;
             }

--- a/SiteSurvey/module.html
+++ b/SiteSurvey/module.html
@@ -355,6 +355,7 @@
                   <button type="button" class="btn btn-fixed-length btn-sm btn-default" data-toggle="modal" data-target="#captureModal" ng-click="viewCapture(entry[1])">View</button>
                   <button type="button" class="btn btn-sm btn-default" ng-click="downloadCapture(entry[1])">Download</button>
 									<button type="button" class="btn btn-fixed-length btn-sm btn-danger" ng-click="deleteCapture(entry[1])">Delete</button>
+									&nbsp <img src="/img/throbber.gif" ng-show="throbber"/>
 								</div>
 							</td>
 	                    </tr>

--- a/SiteSurvey/module.info
+++ b/SiteSurvey/module.info
@@ -6,5 +6,5 @@
         "tetra"
     ],
     "title": "Site Survey",
-    "version": "1.3"
+    "version": "1.4"
 }


### PR DESCRIPTION
When a user captures a WPA handshake, and then selects the download option, the page remains stale while the handshake pcap is downloading.

This change adds the "throbber.gif" to the Action div so a user can see the download is in progress instead of not knowing what happened after the button was clicked.