### PR TITLE
Correctly display interface device names even if it changes

### DIFF
--- a/ConnectedClients/api/module.php
+++ b/ConnectedClients/api/module.php
@@ -49,10 +49,11 @@ class ConnectedClients extends Module
 	}
 
 	private function getConnectedClients() {
-		exec("iw dev wlan0 station dump | grep Station | awk '{print $2}'", $wlan0clients);
-		exec("iw dev wlan0-1 station dump | grep Station | awk '{print $2}'", $wlan01clients);
-		exec("iw dev wlan1 station dump | grep Station | awk '{print $2}'", $wlan1clients);
-		$this->response = array('wlan0clients' => $wlan0clients, 'wlan01clients' => $wlan01clients, 'wlan1clients' => $wlan1clients);
+		exec("iwconfig 2>/dev/null | grep IEEE | awk '{print $1}'", $wlandev);
+		exec("iw dev $wlandev[0] station dump | grep Station | awk '{print $2}'", $wlan0clients);
+		exec("iw dev $wlandev[1] station dump | grep Station | awk '{print $2}'", $wlan01clients);
+		exec("iw dev $wlandev[2] station dump | grep Station | awk '{print $2}'", $wlan1clients);
+		$this->response = array('wlan0clients' => $wlan0clients, 'wlan01clients' => $wlan01clients, 'wlan1clients' => $wlan1clients, 'wlandev' => $wlandev);
 	}
 
 	private function removeMacAddress() {

--- a/ConnectedClients/js/module.js
+++ b/ConnectedClients/js/module.js
@@ -5,6 +5,7 @@ registerController('ConnectedClientsController', ['$api', '$scope', function($ap
 	$scope.wlan0clients = [];
 	$scope.wlan01clients = [];
 	$scope.wlan1clients = [];
+	$scope.wlandev = [];
 	$scope.dhcplength = 0;
 	$scope.dhcpleases = [];
 	$scope.blacklistlength = 0;
@@ -31,6 +32,7 @@ registerController('ConnectedClientsController', ['$api', '$scope', function($ap
 			$scope.wlan0clients = response.wlan0clients;
 			$scope.wlan01clients = response.wlan01clients;
 			$scope.wlan1clients = response.wlan1clients;
+			$scope.wlandev = response.wlandev;
 		});
 	});
 

--- a/ConnectedClients/module.html
+++ b/ConnectedClients/module.html
@@ -13,17 +13,17 @@
 			<div class="clearfix"></div>
 		</div>
 		<div id="ClientsContainer" class="panel-collapse collapse in">
-			<h3 class="text-center">wlan0</h3>
+			<h3 class="text-center">{{ wlandev[0] }}</h3>
 			<table class="table table-striped table-bordered text-center">
 				<tr><th class="text-center">Mac Address</th><th class="text-center">Disassociate</th><th class="text-center">Deauthenticate</th><th class="text-center">Blacklist</th></tr>
 				<tr ng-repeat="wlan0 in wlan0clients"><td>{{ wlan0 }}</td><td><button type="button" class="btn btn-danger" ng-click="disassociateMac(wlan0)">Disassociate</button></td><td><button type="button" class="btn btn-danger" ng-click="deauthenticateMac(wlan0)">Deauthenticate</button></td><td><button type="button" class="btn btn-danger" ng-click="addMacAddress(wlan0)">Blacklist</button></td></tr>
 			</table>
-			<h3 class="text-center">wlan0-1</h3>
+			<h3 class="text-center">{{ wlandev[1] }}</h3>
 			<table class="table table-striped table-bordered text-center">
 				<tr><th class="text-center">Mac Address</th><th class="text-center">Disassociate</th><th class="text-center">Deauthenticate</th><th class="text-center">Blacklist</th></tr>
 				<tr ng-repeat="wlan01 in wlan01clients"><td>{{ wlan01 }}</td><td><button type="button" class="btn btn-danger" ng-click="disassociateMac(wlan01)">Disassociate</button></td><td><button type="button" class="btn btn-danger" ng-click="deauthenticateMac(wlan01)">Deauthenticate</button></td><td><button type="button" class="btn btn-danger" ng-click="addMacAddress(wlan01)">Blacklist</button></td></tr>
 			</table>
-			<h3 class="text-center">wlan1</h3>
+			<h3 class="text-center">{{ wlandev[2] }}</h3>
 			<table class="table table-striped table-bordered text-center">
 				<tr><th class="text-center">Mac Address</th><th class="text-center">Disassociate</th><th class="text-center">Deauthenticate</th><th class="text-center">Blacklist</th></tr>
 				<tr ng-repeat="wlan1 in wlan1clients"><td>{{ wlan1 }}</td><td><button type="button" class="btn btn-danger" ng-click="disassociateMac(wlan1)">Disassociate</button></td><td><button type="button" class="btn btn-danger" ng-click="deauthenticateMac(wlan1)">Deauthenticate</button></td><td><button type="button" class="btn btn-danger" ng-click="addMacAddress(wlan1)">Blacklist</button></td></tr>


### PR DESCRIPTION
It is assumed the device names are wlan0, wlan0-1 and wlan1. This is not always the case. If you add a usb hub to support multiple devices, the naming could change. In my setup and tinkering this could be wlan0, wlan1 and wlan1-1 or wlan0, wlan2, wlan2-1, etc.