### PR TITLE
OpenVPNConnect 1.3 Update - RCE Bug Fix and Dependency Handling Bug Fix

### DIFF
--- a/OpenVPNConnect/api/module.php
+++ b/OpenVPNConnect/api/module.php
@@ -27,7 +27,7 @@ class OpenVPNConnect extends Module{
                 $this->initializeModule();
                 break;
             case 'handleDependencies':
-                $this->handleDependencies();
+                $this->handleDependencies(false);
                 break;
             case 'handleDependenciesSDCard':
                 $this->handleDependenciesSDCard();
@@ -103,7 +103,6 @@ class OpenVPNConnect extends Module{
 
     // Handles dependency installation and removal
     private function handleDependencies($sd){
-    
 
         if($this->checkDependency('openvpn')){
             $this->execBackground('opkg remove openvpn-openssl');
@@ -158,7 +157,7 @@ class OpenVPNConnect extends Module{
         $open_vpn_cmd = "openvpn --log /pineapple/modules/OpenVPNConnect/log/vpn.log --status /pineapple/modules/OpenVPNConnect/log/status.log --config ";
         
         if($inputData[0] != ''){
-            $config_name = $inputData[0];
+            $config_name = escapeshellcmd($inputData[0]);
             $open_vpn_cmd .= "/root/vpn_config/" . $config_name . " ";
         }else{
             $this->response = array("success" => false,
@@ -189,7 +188,7 @@ class OpenVPNConnect extends Module{
 
 
         if($inputData[3] != ''){
-            $openvpn_flags = $inputData[3];
+            $openvpn_flags = escapeshellcmd($inputData[3]);
             $open_vpn_cmd .= $openvpn_flags;
         }
 

--- a/OpenVPNConnect/js/module.js
+++ b/OpenVPNConnect/js/module.js
@@ -43,7 +43,7 @@ registerController('openVPNConnectController', ['$api', '$scope', '$timeout', '$
 
                 $timeout(function() {$window.location.reload();}, 5000);
             }
-            //console.log(response) //Log the response to the console, this is useful for debugging.
+           //console.log(response) //Log the response to the console, this is useful for debugging.
         });
 
     }

--- a/OpenVPNConnect/module.html
+++ b/OpenVPNConnect/module.html
@@ -141,15 +141,23 @@
 								</div>
 								<div id="collapseChangelog" class="panel-collapse collapse">
 									<div class="panel-body">
-										<ul>
+											<ul>
 											<li>
-												<b>1.0.2 </b>
+												<b>1.3 </b>
+											</li>
+											<ul>
+												<li class="text-muted">Now with no RCEs :D...Fixed a major RCE caused by not sanitizing user input when passing in certain OpenVPN parameters.</li>
+                                                <li class="text-muted">Added stability improvements for package management for those with fresh upgrades to 2.6.X WiFi Pineapple firmware.</li>
+                                                <li class="text-muted">Lastly, revised the revision numbers to fall in line with the formal releases.</li>
+											</ul>
+											<li>
+												<b>1.2 </b>
 											</li>
 											<ul>
 												<li class="text-muted">Added in current status when revisiting page, logging, and ability to install dependencies to SD card or local storage. Also squashed some bugs :)</li>
 											</ul>
 											<li>
-												<b>1.0.1 </b>
+												<b>1.1 </b>
 											</li>
 											<ul>
 												<li class="text-muted">Minor Revisions: Added better iptables management with dynamic gateway and the ability to use auth-user-pass. Unofficial Release (Github Only)</li>

--- a/OpenVPNConnect/module.info
+++ b/OpenVPNConnect/module.info
@@ -6,5 +6,5 @@
         "tetra"
     ],
     "title": "OpenVPNConnect",
-    "version": "1.2"
+    "version": "1.3"
 }


### PR DESCRIPTION
An RCE existed due improperly sanitized parameters in the config name and optional flags parameter. While it is true that once you are logged into a wifi pineapple, you should technically already have the root password, this was not intended functionality and is a vulnerability that should not exist. This has been fixed in this release.

Additionally, upstream improvements to firmware 2.6.x were made that resolve Issue https://github.com/InjectionSoftwareDevelopment/OpenVPNConnect/issues/12 on my main dev branch, but unfortunately a bug was introduced at some point that caused dependency installation and handling to result in a 500 error response. This showed its face in the latest firmware release and was resolved by properly passing a default "false" parameter to the appropriate API function for handling dependencies.

(Apologies for the duplicate requests, the former was goof up on my end, I miss clicked during a dev branch PR. This is the real PR!)